### PR TITLE
Experiment: use Z with explicit mod p as field

### DIFF
--- a/Garden/Plonky3/M.v
+++ b/Garden/Plonky3/M.v
@@ -250,6 +250,20 @@ Definition cube (x : Z) : M.t Z :=
   )).
 Opaque cube.
 
+Ltac show_equality_modulo :=
+  repeat (
+    (
+      (
+        apply Zplus_eqm ||
+        apply Zmult_eqm ||
+        apply Zopp_eqm
+      );
+      unfold eqm
+    ) ||
+    rewrite Zmod_eqm ||
+    reflexivity
+  ).
+
 Lemma cube_correct (p : Z) (x : Z) :
   IsPrime p ->
   {{ M.eval p (cube x) 🔽 (x * x * x) mod p, True }}.
@@ -261,8 +275,7 @@ Proof.
     eapply Run.Replace. {
       apply Run.Pure.
     }
-    (* This property should be handled automatically by some field reasoning tactic. *)
-    admit.
+    show_equality_modulo.
   }
   tauto.
-Admitted.
+Qed.


### PR DESCRIPTION
In addition to using `Z` for everything, we simplify the reasoning rules for the monad by using evaluation for the arithmetic operations.

Maybe we can do all the reasoning with the tactics `lia` and `nia`, plus a few axioms and utilities.