### PR TITLE
feat: updated skeleton AIR and primefield

### DIFF
--- a/Garden/Plonky3/air/AirStructure.v
+++ b/Garden/Plonky3/air/AirStructure.v
@@ -1,0 +1,59 @@
+Require Export Coq.ZArith.ZArith.
+Require Export Coq.Lists.List.
+Import ListNotations.
+Require Export primefield.  
+Open Scope Z_scope.
+
+Module AIR (F : PrimeField).
+  
+  Inductive Var := 
+    | LocalVar : nat -> Var 
+    | NextVar : nat -> Var.  
+  
+  Inductive Expr :=
+    | Const : F.F -> Expr
+    | FromVariable : Var -> Expr
+    | Add : Expr -> Expr -> Expr
+    | Mul : Expr -> Expr -> Expr
+    | Sub : Expr -> Expr -> Expr.
+  
+  (* Builder type for constructing AIR constraints. Every element should evaluate to zero. *)
+  Record AirBuilder := {
+    constraints : list Expr;
+  }.
+  
+  (* Basic operations on the AIR builder *)
+  Definition new_builder : AirBuilder := {| constraints := [] |}.
+  
+  Definition assert_eq (builder : AirBuilder) (lhs rhs : Expr) : AirBuilder :=
+    {| constraints := Sub lhs rhs :: builder.(constraints) |}.
+    
+  Definition assert_bool (builder : AirBuilder) (expr : Expr) : AirBuilder :=
+    let zero := Const F.zero in
+    let one := Const F.one in
+    let bool_constraint := Mul expr (Sub expr one) in
+    assert_eq builder bool_constraint zero.
+  
+  (* Pack bits as an expression *)
+  Fixpoint pack_bits_le_helper (bits : list Expr) (acc : Expr) (place : nat) : Expr :=
+    match bits with
+    | [] => acc
+    | bit :: rest =>
+      let place_val := Const (F.of_nat (2^place)) in
+      let term := Mul bit place_val in
+      pack_bits_le_helper rest (Add acc term) (S place)
+    end.
+  
+  Definition pack_bits_le (bits : list Expr) : Expr :=
+    pack_bits_le_helper bits (Const F.zero) 0.
+  
+  (* Core AIR interface types *)
+  Class BaseAir := {
+    width : nat;  (* Width of the AIR trace *)
+  }.
+  
+  Class AirConstraints := {
+    base_air :: BaseAir;
+    eval : AirBuilder -> AirBuilder;  (* Evaluate AIR constraints *)
+  }.
+End AIR.

--- a/Garden/Plonky3/air/AirStructure.v
+++ b/Garden/Plonky3/air/AirStructure.v
@@ -54,6 +54,17 @@ Module AIR (F : PrimeField).
   
   Class AirConstraints := {
     base_air :: BaseAir;
-    eval : AirBuilder -> AirBuilder;  (* Evaluate AIR constraints *)
+    eval_air_builder : AirBuilder -> AirBuilder;  (* Evaluate AIR constraints *)
   }.
+
+  Class Circuits := {
+    air_constraints : AirConstraints;
+    (* the AIR module should only be instantiated with a prime field, 
+       so field characteristic is implicitly specified upon creation. 
+       Such integer parameter should be specified by accessing F.p.
+       *)
+    eval : Z -> Prop;
+  }.
+
+  
 End AIR.

--- a/Garden/Plonky3/air/AirStructure.v
+++ b/Garden/Plonky3/air/AirStructure.v
@@ -11,7 +11,7 @@ Module AIR (F : PrimeField).
     | NextVar : nat -> Var.  
   
   Inductive Expr :=
-    | Const : F.F -> Expr
+    | Const : Z -> Expr
     | FromVariable : Var -> Expr
     | Add : Expr -> Expr -> Expr
     | Mul : Expr -> Expr -> Expr

--- a/Garden/Plonky3/air/blake3Air.v
+++ b/Garden/Plonky3/air/blake3Air.v
@@ -1,4 +1,4 @@
-Require Export ZArith.
+Require Export Coq.ZArith.ZArith.
 Require Export List.
 Import ListNotations.
 Require Export AirStructure.
@@ -101,4 +101,14 @@ Module Blake3AIR (F : PrimeField).
       builder
     | _, _, _, _ => builder (* Invalid input *)
     end.
+
+  Definition xor_32_shift (builder : AirBuilder) (a b c : list Var) (shift : nat) : AirBuilder :=
+    match a, length b, length c with
+    | [a0; a1], 32%nat, 32%nat =>
+        let builder := fold_left (fun builder' var => assert_bool builder' (FromVariable var)) c builder in
+
+      builder
+    | _, _, _ => builder (* Invalid input - should have exactly 2 limbs each *)
+    end.
+
 End Blake3AIR.

--- a/Garden/Plonky3/air/blake3Air.v
+++ b/Garden/Plonky3/air/blake3Air.v
@@ -1,0 +1,104 @@
+Require Export ZArith.
+Require Export List.
+Import ListNotations.
+Require Export AirStructure.
+Open Scope Z_scope.
+
+
+
+
+Module Blake3AIR (F : PrimeField).
+
+  Module AIRInstance := AirStructure.AIR(F).
+  Import AIRInstance.
+  
+  
+  (* Blake3 constants *)
+  Definition BITS_PER_LIMB := 16.
+  Definition U32_LIMBS := 2.
+
+  (* IV constants for Blake3 *)
+  Definition IV : list (list F.F) :=
+    [
+      [F.of_Z 0xE667; F.of_Z 0x6A09];
+      [F.of_Z 0xAE85; F.of_Z 0xBB67];
+      [F.of_Z 0xF372; F.of_Z 0x3C6E];
+      [F.of_Z 0xF53A; F.of_Z 0xA54F];
+      [F.of_Z 0x527F; F.of_Z 0x510E];
+      [F.of_Z 0x688C; F.of_Z 0x9B05];
+      [F.of_Z 0xD9AB; F.of_Z 0x1F83];
+      [F.of_Z 0xCD19; F.of_Z 0x5BE0]
+    ].
+
+  
+
+  (* Implementation of add2 as in the Rust code *)
+  Definition add2 (builder : AirBuilder) (a : list Var) (b : list Var) (c : list Expr) : AirBuilder :=
+    match a, b, c with
+    | [a0; a1], [b0; b1], [c0; c1] =>
+      (* By assumption p > 2^17 so 1 << 16 will be less than p *)
+      let two_16 := Const (F.of_Z (2^16)) in
+      let two_32 := Const (F.of_Z (2^32)) in
+
+      (* conversion from variable to expression *)
+      let a0 := FromVariable a0 in
+      let a1 := FromVariable a1 in
+      let b0 := FromVariable b0 in
+      let b1 := FromVariable b1 in
+      
+      (* Calculate acc_16 = a[0] - b[0] - c[0] *)
+      let acc_16 := Sub a0 (Add b0 c0) in
+      
+      (* Calculate acc_32 = a[1] - b[1] - c[1] *)
+      let acc_32 := Sub a1 (Add b1 c1) in
+      
+      (* Calculate acc = acc_16 + acc_32 * 2^16 *)
+      let shifted_acc_32 := Mul acc_32 two_16 in
+      let acc := Add acc_16 shifted_acc_32 in
+      
+      (* Assert acc * (acc + 2^32) = 0 *)
+      let constraint1 := Mul acc (Add acc two_32) in
+      
+      (* Assert acc_16 * (acc_16 + 2^16) = 0 *)
+      let constraint2 := Mul acc_16 (Add acc_16 two_16) in
+      
+      (* Add both constraints to the builder *)
+      let builder := assert_eq builder constraint1 (Const F.zero) in
+      let builder := assert_eq builder constraint2 (Const F.zero) in
+      
+      builder
+    | _, _, _ => builder (* Invalid input - should have exactly 2 limbs each *)
+    end.
+
+  (* Implementation of add3 as per the Rust signature *)
+  Definition add3 (builder : AirBuilder) (a : list Var) (b : list Var) (c : list Expr) (d : Expr) : AirBuilder :=
+    match a, b, c with
+    | [a0; a1], [b0; b1], [c0; c1] =>
+      (* Similar to add2, but with three addends *)
+      let two_16 := Const (F.of_Z (2^16)) in
+      let two_32 := Mul two_16 two_16 in
+      
+      (* Calculate acc_16 = a[0] - b[0] - c[0] - d (assuming d affects only low limb) *)
+      let acc_16 := Sub (FromVariable a0) (Add (Add (FromVariable b0) c0) d) in
+      
+      (* Calculate acc_32 = a[1] - b[1] - c[1] (no carry handling yet) *)
+      let acc_32 := Sub (FromVariable a1) (Add (FromVariable b1) c1) in
+      
+      (* Calculate acc = acc_16 + acc_32 * 2^16 *)
+      let shifted_acc_32 := Mul acc_32 two_16 in
+      let acc := Add acc_16 shifted_acc_32 in
+      
+      (* Assert acc * (acc + 2^32) = 0 *)
+      let constraint1 := Mul acc (Add acc two_32) in
+      
+      (* Assert acc_16 * (acc_16 + 2^16) = 0 *)
+      let constraint2 := Mul acc_16 (Add acc_16 two_16) in
+      
+      (* Add both constraints to the builder *)
+      let builder := assert_eq builder constraint1 (Const F.zero) in
+      let builder := assert_eq builder constraint2 (Const F.zero) in
+      
+      builder
+    | _, _, _ => builder (* Invalid input *)
+    end.
+End Blake3AIR.

--- a/Garden/Plonky3/air/blake3Air.v
+++ b/Garden/Plonky3/air/blake3Air.v
@@ -16,16 +16,16 @@ Module Blake3AIR (F : PrimeField).
   Definition U32_LIMBS := 2.
 
   (* IV constants for Blake3 *)
-  Definition IV : list (list F.F) :=
+  Definition IV : list (list Z) :=
     [
-      [F.of_Z 0xE667; F.of_Z 0x6A09];
-      [F.of_Z 0xAE85; F.of_Z 0xBB67];
-      [F.of_Z 0xF372; F.of_Z 0x3C6E];
-      [F.of_Z 0xF53A; F.of_Z 0xA54F];
-      [F.of_Z 0x527F; F.of_Z 0x510E];
-      [F.of_Z 0x688C; F.of_Z 0x9B05];
-      [F.of_Z 0xD9AB; F.of_Z 0x1F83];
-      [F.of_Z 0xCD19; F.of_Z 0x5BE0]
+      [0xE667; 0x6A09];
+      [0xAE85; 0xBB67];
+      [0xF372; 0x3C6E];
+      [0xF53A; 0xA54F];
+      [0x527F; 0x510E];
+      [0x688C; 0x9B05];
+      [0xD9AB; 0x1F83];
+      [0xCD19; 0x5BE0]
     ].
 
   
@@ -35,8 +35,8 @@ Module Blake3AIR (F : PrimeField).
     match a, b, c with
     | [a0; a1], [b0; b1], [c0; c1] =>
       (* By assumption p > 2^17 so 1 << 16 will be less than p *)
-      let two_16 := Const (F.of_Z (2^16)) in
-      let two_32 := Const (F.of_Z (2^32)) in
+      let two_16 := Const (2^16) in
+      let two_32 := Const (2^32) in
 
       (* conversion from variable to expression *)
       let a0 := FromVariable a0 in
@@ -73,10 +73,10 @@ Module Blake3AIR (F : PrimeField).
     match a, b, c, d with
     | [a0; a1], [b0; b1], [c0; c1], [d0; d1] =>
       (* Similar to add2, but with three addends *)
-      let two_16 := Const (F.of_Z (2^16)) in
-      let two_32 := Const (F.of_Z (2^32)) in
-      let double_two_16 := Const (F.of_Z (2^17)) in
-      let double_two_32 := Const (F.of_Z (2^33)) in
+      let two_16 := Const (2^16) in
+      let two_32 := Const (2^32) in
+      let double_two_16 := Const (2^17) in
+      let double_two_32 := Const (2^33) in
       
       (* Calculate acc_16 = a[0] - b[0] - c[0] - d[0] (assuming d affects only low limb) *)
       let acc_16 := Sub (FromVariable a0) (Add (Add (FromVariable b0) c0) d0) in

--- a/Garden/Plonky3/air/primefield.v
+++ b/Garden/Plonky3/air/primefield.v
@@ -6,35 +6,35 @@ Open Scope Z_scope.
 
 Module Type PrimeField.
   Parameter p : Z. (* The prime characteristic *)
-  Definition mod_p (x : Z) : Z := Z.modulo x p.
+  Parameter mod_p : Z -> Z.
   
   (* field operations *)
-  Definition zero : Z := 0.
-  Definition one : Z := 1.
-  Definition add (a b : Z) : Z := mod_p (a + b).
-  Definition mul (a b : Z) : Z := mod_p (a * b).
-  Definition neg (a : Z) : Z := mod_p (p - a).
-  Definition sub (a b : Z) : Z := mod_p (a + p - b).
+  Parameter zero : Z.
+  Parameter one : Z.
+  Parameter add : Z -> Z -> Z.
+  Parameter mul : Z -> Z -> Z.
+  Parameter neg : Z -> Z.
+  Parameter sub : Z -> Z -> Z.
 
   (* inv and div only works for non-zeroes. *)
-  Definition inv (a : Z) : Z := mod_p (a ^ (p - 2)).
-  Definition div (a b : Z) : Z := mul a (inv b).
+  Parameter inv : Z -> Z.
+  Parameter div : Z -> Z -> Z.
   
-  (* integer conversions *)
-  Definition of_nat (n : nat) : Z := Z.of_nat n.
-  Definition to_nat (a : Z) : nat := Z.to_nat a.
-  Definition of_bool (b : bool) : Z := if b then one else zero.
+  (* integer & bool conversions *)
+  Parameter of_nat : nat -> Z.
+  Parameter to_nat : Z -> nat.
+  Parameter of_bool : bool -> Z.
   
   (* Field properties *)
   Parameter p_prime : IsPrime p.
   
   (* Additional operations in field.rs *)
-  Definition double (a : Z) : Z := add a a.
-  Definition square (a : Z) : Z := mul a a.
-  Definition cube (a : Z) : Z := mul (square a) a.
-  Definition xor (a b : Z) : Z := sub (add a b) (mul a (double b)).
-  Definition xor3 (a b c : Z) : Z := xor (xor a b) c.
-  Definition andn (a b : Z) : Z := mul (sub one a) b.
+  Parameter double : Z -> Z.
+  Parameter square : Z -> Z.
+  Parameter cube : Z -> Z.
+  Parameter xor : Z -> Z -> Z.
+  Parameter xor3 : Z -> Z -> Z -> Z.
+  Parameter andn : Z -> Z -> Z.
   
   (* Basic algebraic properties *)
   Axiom add_comm : forall a b, add a b = add b a.
@@ -146,3 +146,33 @@ Module Mersenne31Parameter <: PrimeParameter.
 End Mersenne31Parameter.
 
 Module Mersenne31 := MakePrimeField(Mersenne31Parameter).
+
+(* Define BabyBear prime, 2^31 - 2^27 + 1, as the prime parameter module *)
+Module BabyBearParameter <: PrimeParameter.
+  Definition p : Z := 2^31 - 2^27 + 1.
+  
+  Lemma p_prime : IsPrime p.
+  Proof. Admitted.
+End BabyBearParameter.
+
+Module BabyBear := MakePrimeField(BabyBearParameter).
+
+
+(* Define KoalaBear prime field, 2^31 - 2^24 + 1 *)
+Module KoalaBearParameter <: PrimeParameter.
+  Definition p : Z := 2^31 - 2^27 + 1.
+  
+  Lemma p_prime : IsPrime p.
+  Proof. Admitted.
+End KoalaBearParameter.
+
+Module KoalaBear := MakePrimeField(KoalaBearParameter).
+
+(* Define Goldilocks prime field, which is 2^64 - 2^32 + 1 *)
+Module GoldilocksParameter <: PrimeParameter.
+  Definition p : Z := 2^64 - 2^32 + 1.
+  
+  Lemma p_prime : IsPrime p.
+  Proof. Admitted.
+End GoldilocksParameter.
+Module Goldilocks := MakePrimeField(GoldilocksParameter).

--- a/Garden/Plonky3/air/primefield.v
+++ b/Garden/Plonky3/air/primefield.v
@@ -9,6 +9,8 @@ Module Type PrimeField.
   (* unused abstraction: Parameter F : Type. *)
   Parameter p : Z.  (* The prime characteristic *)
 
+  Definition mod_p (x : Z) : Z := Z.modulo x p.
+
   (* 
     later we need an assertion here that all operations are
     within the prime field with characteristic p,
@@ -16,14 +18,23 @@ Module Type PrimeField.
   *)
 
   (* field operations *)
-  Parameter zero : Z.
-  Parameter one : Z.
-  Parameter add : Z -> Z -> Z.
-  Parameter sub : Z -> Z -> Z.
-  Parameter neg : Z -> Z.
-  Parameter mul : Z -> Z -> Z.
-  Parameter inv : Z -> Z.
-  Parameter div : Z -> Z -> Z.
+  Definition zero : Z := 0.
+  Definition one : Z := 1.
+  Definition add (a b : Z) : Z := 
+    mod_p (a + b).
+  
+  Definition mul (a b : Z) : Z :=
+    mod_p (a * b).
+    
+  Definition neg (a : Z) : Z :=
+    mod_p (p - a).
+    
+  Definition sub (a b : Z) : Z :=
+    mod_p (a + p - b).
+    
+  Definition inv (a : Z) : Z := mod_p (a ^ (p - 2)).
+
+  Definition div (a b : Z) : Z := mul a (inv b).
 
   (* integer conversions *)
   (*
@@ -33,12 +44,25 @@ Module Type PrimeField.
   Parameter of_Z : Z -> F.
   Parameter to_Z : F -> Z.
   *)
-  Parameter of_nat : nat -> Z.
-  Parameter to_nat : Z -> nat.
-  Parameter of_bool : bool -> Z.
+
+  Definition of_nat (n : nat) : Z := Z.of_nat n.
+  Definition to_nat (a : Z) : nat := Z.to_nat a.
+  Definition of_bool (b : bool) : Z := if b then one else zero.
 
   (* Field properties *)
   Parameter p_prime : IsPrime p.
+
+  (* Additional operations in field.rs *)
+  Definition double (a : Z) : Z := add a a.
+  Definition square (a : Z) : Z := mul a a.
+  Definition cube (a : Z) : Z := mul (square a) a.
+
+  (* for boolean inputs only. *)
+  Definition xor (a b : Z) : Z := sub (add a b) (mul a (double b)).
+  Definition xor3 (a b c : Z) : Z := xor (xor a b) c.
+  Definition andn (a b : Z) : Z := mul (sub one a) b.
+
+
 
   (* Basic algebraic properties *)
   Axiom add_comm : forall a b, add a b = add b a.
@@ -59,10 +83,9 @@ Module Type PrimeField.
   (* Boolean to field conversion *)
   Axiom of_bool_true : of_bool true = one.
   Axiom of_bool_false : of_bool false = zero.    
-
 End PrimeField.
 
-(* An implementation: Mersenne prime p = 2^31 - 1.
+(* (* An implementation: Mersenne prime p = 2^31 - 1.
   The computations here are done primitively, especially the implementation of inverse.
   Later we could replace the implementations with mathcomp.
  *)
@@ -138,4 +161,4 @@ Module Mersenne31 <: PrimeField.
   Axiom of_bool_true : of_bool true = one.
   Axiom of_bool_false : of_bool false = zero.    
 End Mersenne31.
-
+ *)

--- a/Garden/Plonky3/air/primefield.v
+++ b/Garden/Plonky3/air/primefield.v
@@ -1,0 +1,146 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Plonky3.M.
+Require Import Coq.ZArith.Znumtheory.
+Open Scope Z_scope.
+
+
+
+Module Type PrimeField.
+  Parameter F : Type.
+  Parameter p : Z.  (* The prime characteristic *)
+
+  (* field operations *)
+  Parameter zero : F.
+  Parameter one : F.
+  Parameter add : F -> F -> F.
+  Parameter sub : F -> F -> F.
+  Parameter neg : F -> F.
+  Parameter mul : F -> F -> F.
+  Parameter inv : F -> F.
+  Parameter div : F -> F -> F.
+
+  (* integer conversions *)
+  Parameter of_Z : Z -> F.
+  Parameter to_Z : F -> Z.
+  Parameter of_nat : nat -> F.
+  Parameter to_nat : F -> nat.
+  Parameter of_bool : bool -> F.
+
+  (* Field properties *)
+  Parameter p_prime : IsPrime p.
+
+  (* Basic algebraic properties *)
+  Axiom add_comm : forall a b, add a b = add b a.
+  Axiom add_assoc : forall a b c, add (add a b) c = add a (add b c).
+  Axiom mul_comm : forall a b, mul a b = mul b a.
+  Axiom mul_assoc : forall a b c, mul (mul a b) c = mul a (mul b c).
+  Axiom add_zero : forall a, add a zero = a.
+  Axiom mul_one : forall a, mul a one = a.
+  Axiom mul_zero : forall a, mul a zero = zero.
+  Axiom add_neg : forall a, add a (neg a) = zero.
+  Axiom sub_def : forall a b, sub a b = add a (neg b).
+  Axiom div_def : forall a b, div a b = mul a (inv b).
+  Axiom mul_inv : forall a, a <> zero -> mul a (inv a) = one.
+
+  (* Distributivity *)
+  Axiom distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
+  
+  (* Field element equality *)
+  Axiom to_Z_range : forall a, 0 <= to_Z a < p.
+  Axiom of_Z_to_Z : forall a, of_Z (to_Z a) = a.
+  Axiom to_Z_of_Z : forall n, 0 <= n < p -> to_Z (of_Z n) = n.
+  
+  (* Boolean to field conversion *)
+  Axiom of_bool_true : of_bool true = one.
+  Axiom of_bool_false : of_bool false = zero.    
+End PrimeField.
+
+(* An implementation: Mersenne prime p = 2^31 - 1 *)
+Module Mersenne31 <: PrimeField.
+  Definition p := 2^31 - 1.
+  
+  (* We'll represent field elements as Z values in the range [0, p-1] *)
+  Definition F := {x : Z | 0 <= x < p}.
+
+
+  Lemma mod_p_in_range : forall x, 0 <= Z.modulo x p < p.
+  Proof.
+  Admitted.
+  
+  (* Field operations *)
+  Definition zero : F := exist _ 0 (mod_p_in_range 0). 
+  Definition one : F := exist _ 1 (mod_p_in_range 1). 
+
+  Definition mod_p (x : Z) : Z := Z.modulo x p.
+  
+  Definition add (a b : F) : F := 
+    match a, b with
+    | exist _ va _, exist _ vb _ => 
+      exist _ (mod_p (va + vb)) (mod_p_in_range (va + vb))
+    end.
+  
+  Definition mul (a b : F) : F :=
+    match a, b with
+    | exist _ va _, exist _ vb _ => 
+      exist _ (mod_p (va * vb)) (mod_p_in_range (va * vb))
+    end.
+    
+  Definition neg (a : F) : F :=
+    match a with
+    | exist _ va _ =>
+      if Z.eqb va 0 then zero
+      else exist _ (mod_p (-va)) (mod_p_in_range (-va))
+    end.
+    
+  Definition sub (a b : F) : F :=
+    match a, b with
+    | exist _ va _, exist _ vb _ => 
+      exist _ (mod_p (va - vb)) (mod_p_in_range (va - vb))
+    end.
+    
+  Definition inv (a : F) : F :=
+    match a with
+    | exist _ va _ =>
+      if Z.eqb va 0 then zero
+      (* Just a placeholder, we can compute later with either mathcomp or a ^ (p-2). *)
+      else exist _ 1 (mod_p_in_range 1) 
+    end.
+    
+  Definition div (a b : F) : F := mul a (inv b).
+  
+  (* Conversion functions *)
+  Definition of_Z (z : Z) : F := exist _ (mod_p z) (mod_p_in_range z).  (* Proof obligation *)
+  Definition to_Z (a : F) : Z := 
+    match a with
+    | exist _ va _ => va
+    end.
+  
+  Definition of_nat (n : nat) : F := of_Z (Z.of_nat n).
+  Definition to_nat (a : F) : nat := Z.to_nat (to_Z a).
+  Definition of_bool (b : bool) : F := if b then one else zero.
+
+  Axiom p_prime : IsPrime p.
+  Axiom add_comm : forall a b, add a b = add b a.
+  Axiom add_assoc : forall a b c, add (add a b) c = add a (add b c).
+  Axiom mul_comm : forall a b, mul a b = mul b a.
+  Axiom mul_assoc : forall a b c, mul (mul a b) c = mul a (mul b c).
+  Axiom add_zero : forall a, add a zero = a.
+  Axiom mul_one : forall a, mul a one = a.
+  Axiom mul_zero : forall a, mul a zero = zero.
+  Axiom add_neg : forall a, add a (neg a) = zero.
+  Axiom sub_def : forall a b, sub a b = add a (neg b).
+  Axiom div_def : forall a b, div a b = mul a (inv b).
+  Axiom mul_inv : forall a, a <> zero -> mul a (inv a) = one.
+  Axiom distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
+
+
+  (* Field element equality *)
+  Axiom to_Z_range : forall a, 0 <= to_Z a < p.
+  Axiom of_Z_to_Z : forall a, of_Z (to_Z a) = a.
+  Axiom to_Z_of_Z : forall n, 0 <= n < p -> to_Z (of_Z n) = n.
+  
+  (* Boolean to field conversion *)
+  Axiom of_bool_true : of_bool true = one.
+  Axiom of_bool_false : of_bool false = zero.    
+End Mersenne31.
+

--- a/Garden/Plonky3/air/primefield.v
+++ b/Garden/Plonky3/air/primefield.v
@@ -4,66 +4,38 @@ Require Import Coq.ZArith.Znumtheory.
 Open Scope Z_scope.
 
 
-
 Module Type PrimeField.
-  (* unused abstraction: Parameter F : Type. *)
-  Parameter p : Z.  (* The prime characteristic *)
-
+  Parameter p : Z. (* The prime characteristic *)
   Definition mod_p (x : Z) : Z := Z.modulo x p.
-
-  (* 
-    later we need an assertion here that all operations are
-    within the prime field with characteristic p,
-    so all elements are in the range [0, p-1].
-  *)
-
+  
   (* field operations *)
   Definition zero : Z := 0.
   Definition one : Z := 1.
-  Definition add (a b : Z) : Z := 
-    mod_p (a + b).
-  
-  Definition mul (a b : Z) : Z :=
-    mod_p (a * b).
-    
-  Definition neg (a : Z) : Z :=
-    mod_p (p - a).
-    
-  Definition sub (a b : Z) : Z :=
-    mod_p (a + p - b).
-    
+  Definition add (a b : Z) : Z := mod_p (a + b).
+  Definition mul (a b : Z) : Z := mod_p (a * b).
+  Definition neg (a : Z) : Z := mod_p (p - a).
+  Definition sub (a b : Z) : Z := mod_p (a + p - b).
+
+  (* inv and div only works for non-zeroes. *)
   Definition inv (a : Z) : Z := mod_p (a ^ (p - 2)).
-
   Definition div (a b : Z) : Z := mul a (inv b).
-
+  
   (* integer conversions *)
-  (*
-  These two are used as placeholders now 
-  because we temporarily use Z as the field type instead of F as abstraction.
-  =======
-  Parameter of_Z : Z -> F.
-  Parameter to_Z : F -> Z.
-  *)
-
   Definition of_nat (n : nat) : Z := Z.of_nat n.
   Definition to_nat (a : Z) : nat := Z.to_nat a.
   Definition of_bool (b : bool) : Z := if b then one else zero.
-
+  
   (* Field properties *)
   Parameter p_prime : IsPrime p.
-
+  
   (* Additional operations in field.rs *)
   Definition double (a : Z) : Z := add a a.
   Definition square (a : Z) : Z := mul a a.
   Definition cube (a : Z) : Z := mul (square a) a.
-
-  (* for boolean inputs only. *)
   Definition xor (a b : Z) : Z := sub (add a b) (mul a (double b)).
   Definition xor3 (a b c : Z) : Z := xor (xor a b) c.
   Definition andn (a b : Z) : Z := mul (sub one a) b.
-
-
-
+  
   (* Basic algebraic properties *)
   Axiom add_comm : forall a b, add a b = add b a.
   Axiom add_assoc : forall a b c, add (add a b) c = add a (add b c).
@@ -76,89 +48,101 @@ Module Type PrimeField.
   Axiom sub_def : forall a b, sub a b = add a (neg b).
   Axiom div_def : forall a b, div a b = mul a (inv b).
   Axiom mul_inv : forall a, a <> zero -> mul a (inv a) = one.
-
-  (* Distributivity *)
   Axiom distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
-  
-  (* Boolean to field conversion *)
   Axiom of_bool_true : of_bool true = one.
-  Axiom of_bool_false : of_bool false = zero.    
+  Axiom of_bool_false : of_bool false = zero.
 End PrimeField.
 
-(* (* An implementation: Mersenne prime p = 2^31 - 1.
-  The computations here are done primitively, especially the implementation of inverse.
-  Later we could replace the implementations with mathcomp.
- *)
-Module Mersenne31 <: PrimeField.
-  Definition p : Z := 2147483647.  (* 2^31 - 1 *)
+(* Core module type with just the prime *)
+Module Type PrimeParameter.
+  Parameter p : Z.
+  Parameter p_prime : IsPrime p.
+End PrimeParameter.
 
-  (* Modulo utility for all prime fields. *)
+(* Functor that implements all field operations given a prime *)
+Module MakePrimeField (P : PrimeParameter) <: PrimeField.
+  Definition p := P.p.
   Definition mod_p (x : Z) : Z := Z.modulo x p.
-
-  (* Proof that the field is in the range [0, p-1] *)
-  (* This is a placeholder, we will need to prove this later. *)
-  (* We can use Z.modulo to ensure the result is in the range. *)
-  (* The proof obligation is that all operations are within the prime field. *)
   
-  (* Proof obligation: for all x, 0 <= x < p *)
-  Lemma mod_p_in_range : forall x, 0 <= Z.modulo x p < p.
-  Proof.
-  Admitted.
-  
-  (* Field operations, for now use pure integer zero and one,
-  as we are dealing with prime fields. *)
+  (* Field operations *)
   Definition zero : Z := 0.
   Definition one : Z := 1.
-  
-  Definition add (a b : Z) : Z := 
-    mod_p (a + b).
-  
-  Definition mul (a b : Z) : Z :=
-    mod_p (a * b).
-    
-  Definition neg (a : Z) : Z :=
-    mod_p (p - a).
-    
-  Definition sub (a b : Z) : Z :=
-    mod_p (a + p - b).
-    
+  Definition add (a b : Z) : Z := mod_p (a + b).
+  Definition mul (a b : Z) : Z := mod_p (a * b).
+  Definition neg (a : Z) : Z := mod_p (p - a).
+  Definition sub (a b : Z) : Z := mod_p (a + p - b).
   Definition inv (a : Z) : Z := mod_p (a ^ (p - 2)).
-  
-  (* Division is defined as multiplication by the inverse *)
-  (* This is a placeholder, we will need to prove this later. *)
-  (* The proof obligation is that all operations are within the prime field. *)
-    
-    
   Definition div (a b : Z) : Z := mul a (inv b).
   
-  (* Conversion functions *)
-  (* Definition of_Z (z : Z) : F := exist _ (mod_p z) (mod_p_in_range z).  (* Proof obligation *)
-  Definition to_Z (a : F) : Z := 
-    match a with
-    | exist _ va _ => va
-    end. *)
-  
+  (* Integer conversions *)
   Definition of_nat (n : nat) : Z := Z.of_nat n.
   Definition to_nat (a : Z) : nat := Z.to_nat a.
   Definition of_bool (b : bool) : Z := if b then one else zero.
-
-  Axiom p_prime : IsPrime p.
-  Axiom add_comm : forall a b, add a b = add b a.
-  Axiom add_assoc : forall a b c, add (add a b) c = add a (add b c).
-  Axiom mul_comm : forall a b, mul a b = mul b a.
-  Axiom mul_assoc : forall a b c, mul (mul a b) c = mul a (mul b c).
-  Axiom add_zero : forall a, add a zero = a.
-  Axiom mul_one : forall a, mul a one = a.
-  Axiom mul_zero : forall a, mul a zero = zero.
-  Axiom add_neg : forall a, add a (neg a) = zero.
-  Axiom sub_def : forall a b, sub a b = add a (neg b).
-  Axiom div_def : forall a b, div a b = mul a (inv b).
-  Axiom mul_inv : forall a, a <> zero -> mul a (inv a) = one.
-  Axiom distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
-
   
-  (* Boolean to field conversion *)
-  Axiom of_bool_true : of_bool true = one.
-  Axiom of_bool_false : of_bool false = zero.    
-End Mersenne31.
- *)
+  (* Use the provided prime proof *)
+  Definition p_prime := P.p_prime.
+  
+  (* Additional operations *)
+  Definition double (a : Z) : Z := add a a.
+  Definition square (a : Z) : Z := mul a a.
+  Definition cube (a : Z) : Z := mul (square a) a.
+  Definition xor (a b : Z) : Z := sub (add a b) (mul a (double b)).
+  Definition xor3 (a b c : Z) : Z := xor (xor a b) c.
+  Definition andn (a b : Z) : Z := mul (sub one a) b.
+  
+  (* Proofs of field properties *)
+  Lemma add_comm : forall a b, add a b = add b a.
+  Proof.
+    intros a b. unfold add, mod_p.
+    rewrite Z.add_comm. reflexivity.
+  Qed.
+  
+  Lemma add_assoc : forall a b c, add (add a b) c = add a (add b c).
+  Proof. Admitted.
+  
+  Lemma mul_comm : forall a b, mul a b = mul b a.
+  Proof. Admitted.
+  
+  Lemma mul_assoc : forall a b c, mul (mul a b) c = mul a (mul b c).
+  Proof. Admitted.
+  
+  Lemma add_zero : forall a, add a zero = a.
+  Proof. Admitted.
+  
+  Lemma mul_one : forall a, mul a one = a.
+  Proof. Admitted.
+  
+  Lemma mul_zero : forall a, mul a zero = zero.
+  Proof. Admitted.
+  
+  Lemma add_neg : forall a, add a (neg a) = zero.
+  Proof. Admitted.
+  
+  Lemma sub_def : forall a b, sub a b = add a (neg b).
+  Proof. Admitted.
+  
+  Lemma div_def : forall a b, div a b = mul a (inv b).
+  Proof. Admitted.
+  
+  Lemma mul_inv : forall a, a <> zero -> mul a (inv a) = one.
+  Proof. Admitted.
+  
+  Lemma distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
+  Proof. Admitted.
+  
+  Lemma of_bool_true : of_bool true = one.
+  Proof. unfold of_bool, one. reflexivity. Qed.
+  
+  Lemma of_bool_false : of_bool false = zero.
+  Proof. unfold of_bool, zero. reflexivity. Qed.
+End MakePrimeField.
+
+(* Define Mersenne31 prime as the prime parameter module *)
+Module Mersenne31Parameter <: PrimeParameter.
+  Definition p : Z := 2147483647.  (* 2^31 - 1 *)
+  
+  Lemma p_prime : IsPrime p.
+  Proof. Admitted.
+End Mersenne31Parameter.
+
+Module Mersenne31 := MakePrimeField(Mersenne31Parameter).

--- a/Garden/Plonky3/air/primefield.v
+++ b/Garden/Plonky3/air/primefield.v
@@ -17,8 +17,8 @@ Module Type PrimeField.
   Parameter sub : Z -> Z -> Z.
 
   (* inv and div only works for non-zeroes. *)
-  Parameter inv : Z -> Z.
-  Parameter div : Z -> Z -> Z.
+  Parameter inv : Z -> Prop -> Z.
+  Parameter div : Z -> Z -> Prop -> Z.
   
   (* integer & bool conversions *)
   Parameter of_nat : nat -> Z.
@@ -46,8 +46,8 @@ Module Type PrimeField.
   Axiom mul_zero : forall a, mul a zero = zero.
   Axiom add_neg : forall a, add a (neg a) = zero.
   Axiom sub_def : forall a b, sub a b = add a (neg b).
-  Axiom div_def : forall a b, div a b = mul a (inv b).
-  Axiom mul_inv : forall a, a <> zero -> mul a (inv a) = one.
+  Axiom div_def : forall a b, div a b (b <> 0) = mul a (inv b (b <> 0)).
+  Axiom mul_inv : forall a c, a <> zero -> mul a (inv a c) = one.
   Axiom distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).
   Axiom of_bool_true : of_bool true = one.
   Axiom of_bool_false : of_bool false = zero.
@@ -71,8 +71,8 @@ Module MakePrimeField (P : PrimeParameter) <: PrimeField.
   Definition mul (a b : Z) : Z := mod_p (a * b).
   Definition neg (a : Z) : Z := mod_p (p - a).
   Definition sub (a b : Z) : Z := mod_p (a + p - b).
-  Definition inv (a : Z) : Z := mod_p (a ^ (p - 2)).
-  Definition div (a b : Z) : Z := mul a (inv b).
+  Definition inv (a : Z) (c : Prop) : Z := mod_p (a ^ (p - 2)).
+  Definition div (a b : Z) (c : Prop) : Z := mul a (inv b c).
   
   (* Integer conversions *)
   Definition of_nat (n : nat) : Z := Z.of_nat n.
@@ -121,10 +121,10 @@ Module MakePrimeField (P : PrimeParameter) <: PrimeField.
   Lemma sub_def : forall a b, sub a b = add a (neg b).
   Proof. Admitted.
   
-  Lemma div_def : forall a b, div a b = mul a (inv b).
+  Lemma div_def : forall a b, div a b (b <> 0) = mul a (inv b (b <> 0)).
   Proof. Admitted.
   
-  Lemma mul_inv : forall a, a <> zero -> mul a (inv a) = one.
+  Lemma mul_inv : forall a c, a <> zero -> mul a (inv a c) = one.
   Proof. Admitted.
   
   Lemma distrib : forall a b c, mul a (add b c) = add (mul a b) (mul a c).


### PR DESCRIPTION
Without too much complications from mathcomp itself, a definition for basic AIR and gadgets are provided using an axiomatic flavour. I do found many of the operations are duplicated to the M.v so I think they can be combined somehow.