### PR TITLE
Keccak: more progress on determinism

### DIFF
--- a/Garden/Plonky3/M.v
+++ b/Garden/Plonky3/M.v
@@ -56,6 +56,13 @@ Module Array.
     {|
       get index := f (x.(get) index)
     |}.
+
+  Module Eq.
+    Definition t {A : Set} {N : Z} (x y : t A N) : Prop :=
+      forall (i : Z), 0 <= i < N -> x.(get) i = y.(get) i.
+
+    Axiom dec : forall {A : Set} {N : Z} (x y : Array.t A N), {t x y} + {~ t x y}.
+  End Eq.
 End Array.
 
 Module UnOp.
@@ -160,7 +167,7 @@ Module M.
   Definition for_each {A : Set} {N : Z} (f : A -> t unit) (x : Array.t A N) : t unit :=
     for_in_zero_to_n N (fun i => f (Array.get x i)).
 
-  (* helper: acting on all elements in an array, but returning a sum *)    
+  (* helper: acting on all elements in an array, but returning a sum *)
 
   Fixpoint sum_for_in_zero_to_n_aux {p} `{Prime p} (N : nat) (f : Z -> Z) : Z :=
     match N with
@@ -496,3 +503,161 @@ Proof.
   { rewrite <- (Z.mod_unique x p (-1) (p + x)) in *; lia. }
   { rewrite <- (Z.mod_unique x p 0 x) in *; lia. }
 Qed.
+
+(* TODO: prove with Coqtail *)
+Lemma sub_zero_equiv {p} `{Prime p} (x y : Z) :
+  BinOp.sub x y = 0 <->
+  UnOp.from x = UnOp.from y.
+Proof.
+Admitted.
+
+Lemma sum_for_in_zero_to_n_zeros_eq {p} `{Prime p} (N : Z) (f : Z -> Z)
+    (H_body : forall (i : Z), 0 <= i < N -> f i = 0) :
+  M.sum_for_in_zero_to_n N f = 0.
+Proof.
+Admitted.
+
+(** Rewrite rules for field operations. *)
+Module FieldRewrite.
+  Lemma from_zero {p} `{Prime p} : UnOp.from 0 = 0.
+  Proof.
+    reflexivity.
+  Qed.
+  Global Hint Rewrite @from_zero : field_rewrite.
+
+  Lemma from_one {p} `{Prime p} : UnOp.from 1 = 1.
+  Proof.
+  Admitted.
+  Global Hint Rewrite @from_one : field_rewrite.
+
+  Lemma from_from {p} `{Prime p} (x : Z) :
+    UnOp.from (UnOp.from x) = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @from_from : field_rewrite.
+
+  Lemma from_add {p} `{Prime p} (x y : Z) :
+    UnOp.from (BinOp.add x y) = BinOp.add x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @from_add : field_rewrite.
+
+  Lemma add_from_left {p} `{Prime p} (x y : Z) :
+    BinOp.add (UnOp.from x) y = BinOp.add x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @add_from_left : field_rewrite.
+
+  Lemma add_from_right {p} `{Prime p} (x y : Z) :
+    BinOp.add x (UnOp.from y) = BinOp.add x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @add_from_right : field_rewrite.
+
+  Lemma sub_from_left {p} `{Prime p} (x y : Z) :
+    BinOp.sub (UnOp.from x) y = BinOp.sub x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @sub_from_left : field_rewrite.
+
+  Lemma sub_from_right {p} `{Prime p} (x y : Z) :
+    BinOp.sub x (UnOp.from y) = BinOp.sub x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @sub_from_right : field_rewrite.
+
+  Lemma mul_from_left {p} `{Prime p} (x y : Z) :
+    BinOp.mul (UnOp.from x) y = BinOp.mul x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @mul_from_left : field_rewrite.
+
+  Lemma mul_from_right {p} `{Prime p} (x y : Z) :
+    BinOp.mul x (UnOp.from y) = BinOp.mul x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @mul_from_right : field_rewrite.
+
+  Lemma from_sub {p} `{Prime p} (x y : Z) :
+    UnOp.from (BinOp.sub x y) = BinOp.sub x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @from_sub : field_rewrite.
+
+  Lemma from_mul {p} `{Prime p} (x y : Z) :
+    UnOp.from (BinOp.mul x y) = BinOp.mul x y.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @from_mul : field_rewrite.
+
+  Lemma add_zero_left {p} `{Prime p} (x : Z) :
+    BinOp.add 0 x = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @add_zero_left : field_rewrite.
+
+  Lemma add_zero_right {p} `{Prime p} (x : Z) :
+    BinOp.add x 0 = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+    f_equal; lia.
+  Qed.
+  Global Hint Rewrite @add_zero_right : field_rewrite.
+
+  Lemma sub_zero_left {p} `{Prime p} (x : Z) :
+    BinOp.sub 0 x = UnOp.from (-x).
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @sub_zero_left : field_rewrite.
+
+  Lemma sub_zero_right {p} `{Prime p} (x : Z) :
+    BinOp.sub x 0 = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+    f_equal; lia.
+  Qed.
+  Global Hint Rewrite @sub_zero_right : field_rewrite.
+
+  Lemma mul_zero_left {p} `{Prime p} (x : Z) :
+    BinOp.mul 0 x = 0.
+  Proof.
+    show_equality_modulo.
+  Qed.
+  Global Hint Rewrite @mul_zero_left : field_rewrite.
+
+  Lemma mul_zero_right {p} `{Prime p} (x : Z) :
+    BinOp.mul x 0 = 0.
+  Proof.
+    show_equality_modulo.
+    now replace (x * 0) with 0 by lia.
+  Qed.
+  Global Hint Rewrite @mul_zero_right : field_rewrite.
+
+  Lemma mul_one_left {p} `{Prime p} (x : Z) :
+    BinOp.mul 1 x = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+    now replace (1 * x) with x by lia.
+  Qed.
+  Global Hint Rewrite @mul_one_left : field_rewrite.
+
+  Lemma mul_one_right {p} `{Prime p} (x : Z) :
+    BinOp.mul x 1 = UnOp.from x.
+  Proof.
+    show_equality_modulo.
+    now replace (x * 1) with x by lia.
+  Qed.
+  Global Hint Rewrite @mul_one_right : field_rewrite.
+End FieldRewrite.

--- a/Garden/Plonky3/keccak/air.v
+++ b/Garden/Plonky3/keccak/air.v
@@ -193,7 +193,7 @@ Definition eval
             )
             (List.map Z.of_nat (List.seq 0 5)) 0 in
           let diff := BinOp.sub sum (Array.get (Array.get local.(KeccakCols.c_prime) x) z) in
-          BinOp.mul diff (BinOp.mul (BinOp.sub diff 2) (BinOp.sub diff four))
+          BinOp.mul (BinOp.mul diff (BinOp.sub diff 2)) (BinOp.sub diff four)
         |}
       ) in
 

--- a/Garden/Plonky3/keccak/air_small_parts.v
+++ b/Garden/Plonky3/keccak/air_small_parts.v
@@ -387,7 +387,7 @@ Module a_prime_c_prime.
             )
             (List.map Z.of_nat (List.seq 0 5)) 0 in
           let diff := BinOp.sub sum (Array.get (Array.get local.(KeccakCols.c_prime) x) z) in
-          BinOp.mul diff (BinOp.mul (BinOp.sub diff 2) (BinOp.sub diff four))
+          BinOp.mul (BinOp.mul diff (BinOp.sub diff 2)) (BinOp.sub diff four)
         |}
       ).
 
@@ -409,7 +409,7 @@ Module a_prime_c_prime.
               KeccakCols.get_a_prime local x 4 z
             ] 0 in
           BinOp.sub sum (KeccakCols.get_c_prime local x z) in
-        BinOp.mul diff (BinOp.mul (BinOp.sub diff 2) (BinOp.sub diff 4)) =
+        BinOp.mul (BinOp.mul diff (BinOp.sub diff 2)) (BinOp.sub diff 4) =
         0
       }}.
   Proof.

--- a/Garden/Plonky3/keccak/air_small_parts.v
+++ b/Garden/Plonky3/keccak/air_small_parts.v
@@ -31,9 +31,9 @@ Module preimage_a.
   Lemma implies {p} `{Prime p} (local : KeccakCols.t) :
       let local := M.map_mod local in
       let first_step := local.(KeccakCols.step_flags).(Array.get) 0 in
-      first_step <> 0 ->
       {{ eval local 🔽
         tt,
+        first_step <> 0 ->
         forall (y x limb : Z),
         0 <= y < 5 ->
         0 <= x < 5 ->
@@ -42,19 +42,19 @@ Module preimage_a.
         KeccakCols.get_a local x y limb
       }}.
   Proof.
-    intros * H_not_first_step.
-    eapply Run.Implies. {
-      eapply Run.ForInZeroToN. {
-        intros.
-        eapply Run.ForInZeroToN. {
-          intros.
-          unfold M.when.
-          destruct (_ =? 0) eqn:H_first_step_eq; [lia|].
-          apply Run.AssertZerosFromFnSub.
-        }
+    intros.
+    unfold eval, M.when.
+    destruct (_ =? 0) eqn:?.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
       }
+      lia.
     }
-    hauto l: on drew: off.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
+      }
+      hauto l: on.
+    }
   Qed.
 End preimage_a.
 
@@ -96,9 +96,9 @@ Module preimage_next_preimage.
       let next := M.map_mod next in
       let final_step := local.(KeccakCols.step_flags).(Array.get) (NUM_ROUNDS - 1) in
       let not_final_step := BinOp.sub 1 final_step in
-      not_final_step <> 0 ->
       {{ eval local next true 🔽
         tt,
+        not_final_step <> 0 ->
         forall (y x limb : Z),
         0 <= y < 5 ->
         0 <= x < 5 ->
@@ -107,20 +107,20 @@ Module preimage_next_preimage.
         KeccakCols.get_preimage next x y limb
       }}.
   Proof.
-    intros * H_not_final_step.
-    eapply Run.Implies. {
-      eapply Run.ForInZeroToN. {
-        intros.
-        eapply Run.ForInZeroToN. {
-          intros.
-          unfold M.when.
-          unfold not_final_step, final_step in *.
-          destruct (_ =? 0) eqn:H_not_final_step_eq; [lia|].
-          apply Run.AssertZerosFromFnSub.
-        }
+    intros.
+    unfold eval, M.when.
+    unfold not_final_step, final_step in *.
+    destruct (_ =? 0) eqn:?.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
       }
+      lia.
     }
-    hauto l: on drew: off.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
+      }
+      hauto l: on.
+    }
   Qed.
 End preimage_next_preimage.
 
@@ -139,8 +139,7 @@ Module export_bool.
     {{
       eval local 🔽
       tt,
-      local.(KeccakCols.export) =
-      Z.b2z (Z.odd local.(KeccakCols.export))
+      IsBool.t local.(KeccakCols.export)
     }}.
   Proof.
     intros.
@@ -168,21 +167,26 @@ Module export_zero.
       let local := M.map_mod local in
       let final_step := local.(KeccakCols.step_flags).(Array.get) (NUM_ROUNDS - 1) in
       let not_final_step := BinOp.sub 1 final_step in
-      not_final_step <> 0 ->
       {{ eval local 🔽
         tt,
+        not_final_step <> 0 ->
         local.(KeccakCols.export) = 0
       }}.
   Proof.
     intros.
-    unfold eval.
-    eapply Run.Implies. {
-      unfold M.when.
-      unfold not_final_step, final_step in *.
-      destruct (_ =? 0) eqn:H_not_final_step_eq; [lia|].
-      apply Run.Equal.
+    unfold eval, M.when.
+    unfold not_final_step, final_step in *.
+    destruct (_ =? 0) eqn:?.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
+      }
+      lia.
     }
-    easy.
+    { eapply Run.Implies. {
+        repeat (econstructor || intros).
+      }
+      tauto.
+    }
   Qed.
 End export_zero.
 
@@ -249,7 +253,7 @@ Module c_c_prime.
     eapply Run.Implies. {
       repeat (econstructor || intros).
     }
-    hauto l: on.
+    sauto lq: on rew: off.
   Qed.
 End c_c_prime.
 


### PR DESCRIPTION
In this pull request, there are:

- More progress on the proof for the determinism of Keccak
- A new predicate `IsBool.t` that is often useful to specify circuits
- A set of rewrite rules, to simplify obvious things like multiplication by zero. They can be executed with `autorewrite with field_rewrite`
- Some proof cases where we use an explicit large prime number (here, Goldilocks). It should actually not be a problem to fix the prime number, as circuits are generally executed for a specific zkVM with a specific prime number. The advantage is that it simplifies some reasoning, especially when brute-forcing some equations with only modulos on boolean values.
- An updated specification and proof for BranchEq in OpenVM.