### PR TITLE
ci: updated snapshot command for system compatibility

### DIFF
--- a/Garden/Makefile
+++ b/Garden/Makefile
@@ -21,7 +21,7 @@ all: CoqMakefile
 	$(MAKE) snapshot
 
 snapshot:
-	coqc -R . Garden OpenVM/BranchEq/core_expr.v | tail -n +2 | head -n -2 > OpenVM/BranchEq/core_expr.snapshot
+	coqc -R . Garden OpenVM/BranchEq/core_expr.v | tail -n +2 | sed -e '$d' -e '$d' > OpenVM/BranchEq/core_expr.snapshot
 
 clean-coq: CoqMakefile
 	$(MAKECOQ) clean


### PR DESCRIPTION
the `head -n -2` command is not supported due to difference between BSD linux and macOS. The current version should work on both systems.