### PR TITLE
Orchard: Action statement enhancement — remove witness-honesty hypotheses

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -109,6 +109,41 @@ Personal or not-yet-committed documentation is indexed in `CLAUDE.local.md`
   puts only the validated static bundle on the force-replaced `gh-pages`
   deployment branch.
 
+## Comment and doc style
+
+Write Rocq comments and `docs/` prose for a reader who never saw the change
+history — describe what the code *is*, not how it got that way. These rules
+apply to everything committed: `(* *)`/`(** *)` comments, `docs/`, and this
+file.
+
+- Declarative present tense. No temporal or comparative narration ("no
+  longer", "previously", "now does X", "used to"), no refactoring narration
+  ("factored out of", "moved here from", "this file was split"), and no
+  diff narration ("this is additive", "X is untouched", "X is weakened
+  to") — state the current fact directly.
+- This does not mean "don't explain why" — rationale is the most valuable
+  content a comment can carry. State it as a timeless constraint rather
+  than a story: not "we switched from `f_equal` because it was slow" but
+  "`f_equal` on a primitive projection forces normalization of the shared
+  fold; rewriting in the hypothesis avoids it". History that cannot be
+  rewritten this way belongs in the commit message or PR description, or —
+  when the event itself is the subject — in a dedicated record document in
+  `docs/` with explicit dates.
+- No editorializing that implies contrast with a past or lesser state:
+  "genuine", "real lemma", "honest, true assumptions". (Established
+  technical terms — the "honest branch" of a disjunction — are fine.)
+- No planning or process vocabulary from working notes: campaign, phase,
+  workflow, recon, deferred, future work, TODO, or internal shorthand such
+  as decision-gate labels (D1, D2b, …).
+- Reference only committed files. Never cite local documents — anything
+  uncommitted and not intended for the repository, such as private plan,
+  status, or design notes — a dangling pointer misleads every later
+  reader. Referencing the public documents under `docs/` is fine.
+- Cite the protocol specification as `§x.y.z` (never page numbers), and
+  cite it wherever a statement implements a specific protocol clause.
+- Bracketed references (`[Module.lemma]`, `[file.v]`, `[docs/foo.md]`) and
+  `file:line` citations must resolve — verify them at write time.
+
 ## Proof iteration workflow
 
 Pick the cheapest feedback loop for the scale of the change:

--- a/Garden/Orchard/bundle/homomorphic_sum.v
+++ b/Garden/Orchard/bundle/homomorphic_sum.v
@@ -195,10 +195,10 @@ Module OrchardBundleSum.
         (Pallas.mul (action_rcv Γ)
           PallasGenerators.value_commit_r_G).
   Proof.
-    destruct Hok as (Hcircuit & Hmerkle & Hnote & Hold).
+    destruct Hok as (Hcircuit & Hnew & Hold).
     unfold action_cv_net, action_net_value, action_rcv.
     rewrite (CvNetValue.cv_net_commits_net_value_Z
-      Γ Hcircuit Hmerkle Hnote Hold).
+      Γ Hcircuit Hnew Hold).
     apply unrepr_value_commit.
   Qed.
 

--- a/Garden/Orchard/bundle/main.v
+++ b/Garden/Orchard/bundle/main.v
@@ -67,17 +67,15 @@ Module OrchardBundle.
 
       Each action's net value [v_old - v_new] lies in the open interval
       [(-(2^64), 2^64)]: both note values are 64-bit under the action's
-      hypothesis package (the old-note range through the old-note short
-      lookups, the new-note range through the short-lookup conjunct of
-      the new-note commitment package). *)
+      hypothesis package, each through its lane's short-lookup range
+      family. *)
   Lemma action_net_value_range (Γ : Assignment.t columns RegionId.t)
       (Hok : action_ok Γ) :
     - 2 ^ 64 < action_net_value Γ < 2 ^ 64.
   Proof.
-    destruct Hok as (Hcircuit & _ & Hnote & Hold).
+    destruct Hok as (Hcircuit & Hnew & Hold).
     pose proof (TypedInputsValue64.in_v_old_64 Γ Hcircuit Hold) as Hvold.
-    pose proof (TypedInputsValue64.in_v_new_64 Γ Hcircuit (proj2 Hnote))
-      as Hvnew.
+    pose proof (TypedInputsValue64.in_v_new_64 Γ Hcircuit Hnew) as Hvnew.
     unfold action_net_value.
     clear -Hvold Hvnew; lia.
   Qed.

--- a/Garden/Orchard/bundle/spec.v
+++ b/Garden/Orchard/bundle/spec.v
@@ -43,6 +43,7 @@ Require Import Garden.Orchard.protocol_spec.
 Require Import Garden.Orchard.circuit_proof.inputs.
 Require Import Garden.Orchard.circuit_proof.merkle.
 Require Import Garden.Orchard.circuit_proof.note_commit.cmx.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
 Require Import Garden.Orchard.circuit_proof.old_note.words.
 Require Import Garden.Field.Field.
 Require Import Garden.Plonky3.M.
@@ -159,17 +160,24 @@ Module OrchardBundleSpec.
   (** ** Per-action hypothesis package
 
       Exactly the hypothesis set of
-      [CvNetValue.cv_net_commits_net_value_Z]: the assignment satisfies
-      the circuit, and the three witness-honesty predicates of the
-      relational selector model hold (the Merkle-path layers, the new-note
-      commitment nondegeneracy and short lookups, and the old-note short
-      lookups — the last two feed the 64-bit ranges of [v_old]/[v_new]). *)
+      [CvNetValue.cv_net_commits_net_value_Z]: the assignment satisfies the
+      circuit, and the two short-lookup range families of the relational
+      selector model hold — the residue that feeds the 64-bit ranges of
+      [v_old]/[v_new].  Neither is an assumption about the witness: the
+      deployed circuit enforces both through its range-check lookup
+      argument, and they are discharged from acceptance of the pinned
+      circuit ([circuit_proof/lookup_closure.v],
+      [circuit_proof/lookup_closure_old_note.v]).
+
+      The [CV_NET] row is ⊥-free (complete addition and total group
+      multiples only), so the package carries no Merkle package and no
+      Sinsemilla nondegeneracy: those belong to the anchor and [CMX] rows,
+      which the balance argument never reads. *)
   Definition action_ok (Γ : Assignment.t columns RegionId.t) : Prop :=
     circuit_holds Γ
       Garden.Orchard.circuit.synthesize
       (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty) /\
-    OrchardActionMerkle.merkle_witness_ok Γ /\
-    NoteCommitNewCmx.note_commit_witness_ok Γ /\
+    NoteCommitNewWords.note_commit_new_short_lookup_ok Γ /\
     OldNoteWords.old_note_short_lookup_ok Γ.
 
   (** All actions of the bundle satisfy the per-action package. *)

--- a/Garden/Orchard/bundle/spec.v
+++ b/Garden/Orchard/bundle/spec.v
@@ -166,8 +166,8 @@ Module OrchardBundleSpec.
       [v_old]/[v_new].  Neither is an assumption about the witness: the
       deployed circuit enforces both through its range-check lookup
       argument, and they are discharged from acceptance of the pinned
-      circuit ([circuit_proof/lookup_closure.v],
-      [circuit_proof/lookup_closure_old_note.v]).
+      circuit ([OrchardAdversarialAction.action_ok_operational],
+      [circuit_adversarial.v]).
 
       The [CV_NET] row is ⊥-free (complete addition and total group
       multiples only), so the package carries no Merkle package and no

--- a/Garden/Orchard/circuit_adversarial.v
+++ b/Garden/Orchard/circuit_adversarial.v
@@ -1,0 +1,479 @@
+(** * The Action statement at the acceptance levels: conditional and
+      adversarial
+
+    [orchard_action_statement_operational] ([circuit_operational.v]) and
+    [orchard_algebraic_action_statement] ([compiled/algebraic.v]) carry the
+    §4.18.4 Action statement from acceptance of the pinned Orchard circuit,
+    conditioned on four witness-honesty packages.  Three of those packages
+    split into a nondegeneracy conjunct and a short-lookup range conjunct
+    ([note_commit/cmx.v], [valid_action_inputs.v]).  The short-lookup
+    conjuncts are model artifacts rather than real assumptions: the
+    deployed circuit enforces them through its range-check lookup argument,
+    and only the relational selector model leaves them free
+    ([docs/chip-model-caveats.md]).  They are discharged against the pinned
+    circuit in [circuit_proof/lookup_closure.v],
+    [circuit_proof/lookup_closure_old_note.v] and
+    [circuit_proof/lookup_closure_ivk.v].
+
+    The first half of the file restates the two acceptance-level Action
+    statements with those conjuncts discharged.  The residual hypotheses
+    are exactly the Sinsemilla incomplete-add nondegeneracy of the three
+    hashed message folds and the Merkle package, one predicate per package
+    ([note_commit_nondegenerate], [old_note_nondegenerate],
+    [commit_ivk_nondegenerate]).  The variable-base mul chip's
+    nondegeneracy is not among them: §4.18.4 grants the
+    multiplication of 'Diversified address integrity' no exceptional
+    escape, and [OrchardOwnershipBot.mul_nondegenerate_of_holds]
+    ([circuit_proof/ownership_bot.v]) derives it from the gates.
+
+    The second half is the adversarial statement — the §4.18.4 clauses in
+    the disjunctive form the protocol states them, with the exceptional
+    branches as disjuncts of the conclusion rather than as hypotheses
+    ([circuit_proof/adversarial.v]).  At the acceptance levels every
+    remaining side condition of that statement is a short-lookup range
+    family, so the closure files discharge them all: the only surviving
+    premise is [OrchardAdversarialApi.WellTypedInstance], the typing of the
+    decoded primary input that transaction decoding and consensus enforce.
+    The determinism corollary is likewise conditioned on the inputs alone.
+
+    The heavy certificate files are consumed read-only. *)
+
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.serialize.
+Require Import Garden.Halo2.realize.main.
+Require Import Garden.Halo2.realize.sound.
+Require Import Garden.Halo2.plonkish.poly.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.circuit_synthesis_layout.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.merkle.
+Require Import Garden.Orchard.circuit_proof.note_commit.hash.
+Require Import Garden.Orchard.circuit_proof.note_commit.cmx.
+Require Import Garden.Orchard.circuit_proof.ownership.var_base_mul.
+Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
+Require Import Garden.Orchard.circuit_proof.lookup_closure.
+Require Import Garden.Orchard.circuit_proof.lookup_closure_old_note.
+Require Import Garden.Orchard.circuit_proof.lookup_closure_ivk.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+Require Import Garden.Orchard.circuit_proof.old_note.words.
+Require Import Garden.Orchard.circuit_proof.ownership.commit_ivk_hash.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial_api.
+Require Import Garden.Orchard.circuit_proof.merkle_bot.
+Require Import Garden.Orchard.circuit_proof.ownership_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial.
+Require Import Garden.Orchard.circuit_operational.
+Require Import Garden.Orchard.compiled.algebraic.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Module OrchardAdversarialAction.
+  Import OrchardActionInputs.
+
+  (** ** The residual witness-honesty conditions, one per package
+
+      Each is the witness-honesty package of
+      [circuit_proof/valid_action_inputs.v] and
+      [circuit_proof/note_commit/cmx.v] with its short-lookup conjunct
+      removed.  The Merkle package is carried whole: its
+      [merkle_layer_canonical] conjunct bounds wrapped 255-bit
+      reconstructions, which no acceptance level derives — the deployed
+      decomposition gate checks the sum modulo the field prime only
+      ([circuit_proof/merkle.v]). *)
+
+  (** Sinsemilla nondegeneracy of the 109-word new-note commitment fold. *)
+  Definition note_commit_nondegenerate
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    SinsemillaHash.nondegenerate NoteCommitNewHash.note_commit_Q
+      (NoteCommitNewHash.note_commit_new_words Γ).
+
+  (** Sinsemilla nondegeneracy of the 109-word old-note commitment fold. *)
+  Definition old_note_nondegenerate
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    SinsemillaHash.nondegenerate
+      (OrchardSpec.note_commit_q orchard_circuit_params)
+      (OrchardValidActionInputs.old_note_words Γ).
+
+  (** Sinsemilla nondegeneracy of the 51-word [Commit^ivk] fold — the only
+      chip-level exceptional-case condition of the ownership lane.  The
+      variable-base mul chip's incomplete-addition nondegeneracy is not
+      part of the residue: §4.18.4's 'Diversified address integrity' gives
+      ⊥ to the [Commit^ivk] fold alone and requires the [ivk]
+      decomposition to be canonical, so the multiplication must hold
+      exactly; [OrchardOwnershipBot.mul_nondegenerate_of_holds] derives the
+      chip condition from the gates. *)
+  Definition commit_ivk_nondegenerate
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    SinsemillaHash.nondegenerate
+      (OrchardSpec.commit_ivk_q orchard_circuit_params)
+      (OrchardValidActionInputs.commit_ivk_words Γ).
+
+  (** ** Reassembling the packages from operational acceptance
+
+      Each package is its residue paired with the short-lookup family the
+      closure files derive from replay success and ideal acceptance. *)
+
+  Lemma note_commit_witness_ok_of_nondegenerate
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (Hnd :
+        note_commit_nondegenerate (realize Index.indices region_start_of grid)) :
+    NoteCommitNewCmx.note_commit_witness_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (conj Hnd
+      (OrchardShortLookupClosure.note_commit_new_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)).
+  Qed.
+
+  Lemma old_note_witness_ok_of_nondegenerate
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (Hnd :
+        old_note_nondegenerate (realize Index.indices region_start_of grid)) :
+    OrchardValidActionInputs.old_note_witness_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (conj Hnd
+      (OrchardOldNoteLookupClosure.old_note_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)).
+  Qed.
+
+  Lemma commit_ivk_witness_ok_of_nondegenerate
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (Hnd :
+        commit_ivk_nondegenerate (realize Index.indices region_start_of grid)) :
+    OrchardValidActionInputs.commit_ivk_witness_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (OrchardOwnershipBot.commit_ivk_witness_ok_of_nondegenerate
+      (realize Index.indices region_start_of grid)
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      Hnd
+      (OrchardCommitIvkLookupClosure.commit_ivk_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)).
+  Qed.
+
+  (** ** The Action statement at the ideal operational checker
+
+      [orchard_action_statement_operational] ([circuit_operational.v:543])
+      with the three short-lookup conjuncts discharged.  The premises are
+      replay success, ideal acceptance, and the four residual honesty
+      conditions. *)
+
+  Corollary orchard_action_statement_operational_short_closed
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (Hmerkle_ok :
+        Garden.Orchard.circuit_proof.merkle.OrchardActionMerkle
+          .merkle_witness_ok
+          (realize Index.indices region_start_of grid))
+      (Hnote_nd :
+        note_commit_nondegenerate (realize Index.indices region_start_of grid))
+      (Hold_note_nd :
+        old_note_nondegenerate (realize Index.indices region_start_of grid))
+      (Hivk_nd :
+        commit_ivk_nondegenerate (realize Index.indices region_start_of grid)) :
+    (Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+        .read_action_outputs
+        (realize Index.indices region_start_of grid) =
+      Garden.Orchard.protocol_spec.OrchardProtocolSpec.orchard_action_spec
+        Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+          .orchard_circuit_params
+        (Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+          .read_action_inputs
+          (realize Index.indices region_start_of grid))) /\
+    Garden.Orchard.circuit_proof.valid_action_inputs.OrchardValidActionInputs
+      .ValidActionInputs
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (orchard_action_statement_operational advice instance_ grid
+      Hreplay Hmock Hmerkle_ok
+      (note_commit_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hnote_nd)
+      (old_note_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hold_note_nd)
+      (commit_ivk_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hivk_nd)).
+  Qed.
+
+  (** ** The Action statement at the polynomial-identity layer
+
+      [orchard_algebraic_action_statement] ([compiled/algebraic.v]) with
+      the same three conjuncts discharged.  The ideal acceptance the
+      closure theorems consume is obtained from the algebraic premises by
+      [orchard_algebraic_mock_accepts], so this corollary's premises are
+      those of the algebraic statement, minus the short lookups. *)
+
+  Corollary orchard_algebraic_action_statement_short_closed
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t) (Es : list Poly.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hcanon : OrchardCompiledAlgebraic.orchard_perm_values_canonical grid)
+      (Haccepts : OrchardCompiledAlgebraic.orchard_algebraic_accepts grid Es)
+      (Hmerkle_ok :
+        Garden.Orchard.circuit_proof.merkle.OrchardActionMerkle
+          .merkle_witness_ok
+          (realize Index.indices region_start_of grid))
+      (Hnote_nd :
+        note_commit_nondegenerate (realize Index.indices region_start_of grid))
+      (Hold_note_nd :
+        old_note_nondegenerate (realize Index.indices region_start_of grid))
+      (Hivk_nd :
+        commit_ivk_nondegenerate (realize Index.indices region_start_of grid)) :
+    (Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+        .read_action_outputs
+        (realize Index.indices region_start_of grid) =
+      Garden.Orchard.protocol_spec.OrchardProtocolSpec.orchard_action_spec
+        Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+          .orchard_circuit_params
+        (Garden.Orchard.circuit_proof.inputs.OrchardActionInputs
+          .read_action_inputs
+          (realize Index.indices region_start_of grid))) /\
+    Garden.Orchard.circuit_proof.valid_action_inputs.OrchardValidActionInputs
+      .ValidActionInputs
+      (realize Index.indices region_start_of grid).
+  Proof.
+    pose proof (OrchardCompiledAlgebraic.orchard_algebraic_mock_accepts advice instance_ grid Es
+      Hreplay Hcanon Haccepts) as Hmock.
+    exact (OrchardCompiledAlgebraic.orchard_algebraic_action_statement advice instance_ grid Es
+      Hreplay Hcanon Haccepts Hmerkle_ok
+      (note_commit_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hnote_nd)
+      (old_note_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hold_note_nd)
+      (commit_ivk_witness_ok_of_nondegenerate advice instance_ grid
+        Hreplay Hmock Hivk_nd)).
+  Qed.
+
+  (** ** The adversarial Action statement at the acceptance levels
+
+      [OrchardAdversarial.action_statement_adversarial]
+      ([circuit_proof/adversarial.v]) states the §4.18.4 clause set with
+      the protocol's own ⊥ disjunctions in the conclusion, so no
+      nondegeneracy, canonicity or Merkle hypothesis appears.  Its four
+      remaining side conditions are short-lookup range families of the
+      relational selector model, and all four are discharged here from
+      acceptance of the pinned circuit: the three note/ownership families
+      by the closure files, the 64 Merkle [b_1]/[b_2] sites by
+      [OrchardMerkleBot.merkle_b_range_ok_operational].
+
+      What is left is [OrchardAdversarialApi.WellTypedInstance] alone —
+      Boolean [enableSpends]/[enableOutputs], the consensus rule
+      [rk ≠ 𝒪_P] (§4.6), and the reducedness of the decoded instance
+      rows. *)
+
+  Corollary orchard_action_statement_adversarial_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (Hwti :
+        OrchardAdversarialApi.WellTypedInstance
+          (realize Index.indices region_start_of grid)) :
+    OrchardAdversarialApi.adversarial_action_conclusion
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (OrchardAdversarial.action_statement_adversarial
+      (realize Index.indices region_start_of grid)
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      Hwti
+      (OrchardShortLookupClosure.note_commit_new_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)
+      (OrchardOldNoteLookupClosure.old_note_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)
+      (OrchardCommitIvkLookupClosure.commit_ivk_short_lookup_ok_operational
+        advice instance_ grid Hreplay Hmock)
+      (OrchardMerkleBot.merkle_b_range_ok_operational
+        advice instance_ grid Hreplay Hmock)).
+  Qed.
+
+  (** The same statement at the polynomial-identity layer: the ideal
+      acceptance the closure theorems consume is produced from the
+      algebraic premises by [orchard_algebraic_mock_accepts]. *)
+
+  Corollary orchard_action_statement_adversarial_algebraic
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t) (Es : list Poly.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hcanon : OrchardCompiledAlgebraic.orchard_perm_values_canonical grid)
+      (Haccepts : OrchardCompiledAlgebraic.orchard_algebraic_accepts grid Es)
+      (Hwti :
+        OrchardAdversarialApi.WellTypedInstance
+          (realize Index.indices region_start_of grid)) :
+    OrchardAdversarialApi.adversarial_action_conclusion
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (orchard_action_statement_adversarial_operational advice instance_
+      grid Hreplay
+      (OrchardCompiledAlgebraic.orchard_algebraic_mock_accepts
+        advice instance_ grid Es Hreplay Hcanon Haccepts)
+      Hwti).
+  Qed.
+
+  (** ** Determinism conditioned on the inputs alone, at the acceptance
+         levels
+
+      Two accepted assignments agreeing on [read_action_inputs], on which
+      the ⊥-carrying new-note commitment of those inputs is defined, agree
+      on every public output row.  Both premises are properties of the
+      input record: no witness-honesty condition survives. *)
+
+  Corollary orchard_deterministic_adversarial_operational
+      (advice1 instance1 advice2 instance2 : Z -> Z -> Z)
+      (grid1 grid2 : RawGrid.t)
+      (Hreplay1 :
+        apply_events orchard_events (initial_grid advice1 instance1) =
+          Some grid1)
+      (Hmock1 :
+        mock_prover_accepts orchard_indexed_system orchard_events grid1
+          orchard_table_rows)
+      (Hreplay2 :
+        apply_events orchard_events (initial_grid advice2 instance2) =
+          Some grid2)
+      (Hmock2 :
+        mock_prover_accepts orchard_indexed_system orchard_events grid2
+          orchard_table_rows)
+      (Hinputs :
+        read_action_inputs (realize Index.indices region_start_of grid1) =
+        read_action_inputs (realize Index.indices region_start_of grid2))
+      (Hdef :
+        OrchardAdversarialApi.cmx_bot_of_inputs orchard_circuit_params
+          (read_action_inputs (realize Index.indices region_start_of grid1))
+          <> None) :
+    forall row : Z,
+      row = Garden.Orchard.circuit.ANCHOR \/
+      row = Garden.Orchard.circuit.CV_NET_X \/
+      row = Garden.Orchard.circuit.CV_NET_Y \/
+      row = Garden.Orchard.circuit.NF_OLD \/
+      row = Garden.Orchard.circuit.RK_X \/
+      row = Garden.Orchard.circuit.RK_Y \/
+      row = Garden.Orchard.circuit.CMX ->
+      read_public_instance (realize Index.indices region_start_of grid1) row =
+      read_public_instance (realize Index.indices region_start_of grid2) row.
+  Proof.
+    exact (OrchardAdversarial.deterministic_adversarial
+      (realize Index.indices region_start_of grid1)
+      (realize Index.indices region_start_of grid2)
+      (orchard_operational_sound advice1 instance1 grid1 Hreplay1 Hmock1)
+      (orchard_operational_sound advice2 instance2 grid2 Hreplay2 Hmock2)
+      (OrchardShortLookupClosure.note_commit_new_short_lookup_ok_operational
+        advice1 instance1 grid1 Hreplay1 Hmock1)
+      (OrchardShortLookupClosure.note_commit_new_short_lookup_ok_operational
+        advice2 instance2 grid2 Hreplay2 Hmock2)
+      Hinputs Hdef).
+  Qed.
+
+  Corollary orchard_deterministic_adversarial_algebraic
+      (advice1 instance1 advice2 instance2 : Z -> Z -> Z)
+      (grid1 grid2 : RawGrid.t) (Es1 Es2 : list Poly.t)
+      (Hreplay1 :
+        apply_events orchard_events (initial_grid advice1 instance1) =
+          Some grid1)
+      (Hcanon1 : OrchardCompiledAlgebraic.orchard_perm_values_canonical grid1)
+      (Haccepts1 :
+        OrchardCompiledAlgebraic.orchard_algebraic_accepts grid1 Es1)
+      (Hreplay2 :
+        apply_events orchard_events (initial_grid advice2 instance2) =
+          Some grid2)
+      (Hcanon2 : OrchardCompiledAlgebraic.orchard_perm_values_canonical grid2)
+      (Haccepts2 :
+        OrchardCompiledAlgebraic.orchard_algebraic_accepts grid2 Es2)
+      (Hinputs :
+        read_action_inputs (realize Index.indices region_start_of grid1) =
+        read_action_inputs (realize Index.indices region_start_of grid2))
+      (Hdef :
+        OrchardAdversarialApi.cmx_bot_of_inputs orchard_circuit_params
+          (read_action_inputs (realize Index.indices region_start_of grid1))
+          <> None) :
+    forall row : Z,
+      row = Garden.Orchard.circuit.ANCHOR \/
+      row = Garden.Orchard.circuit.CV_NET_X \/
+      row = Garden.Orchard.circuit.CV_NET_Y \/
+      row = Garden.Orchard.circuit.NF_OLD \/
+      row = Garden.Orchard.circuit.RK_X \/
+      row = Garden.Orchard.circuit.RK_Y \/
+      row = Garden.Orchard.circuit.CMX ->
+      read_public_instance (realize Index.indices region_start_of grid1) row =
+      read_public_instance (realize Index.indices region_start_of grid2) row.
+  Proof.
+    exact (orchard_deterministic_adversarial_operational
+      advice1 instance1 advice2 instance2 grid1 grid2 Hreplay1
+      (OrchardCompiledAlgebraic.orchard_algebraic_mock_accepts
+        advice1 instance1 grid1 Es1 Hreplay1 Hcanon1 Haccepts1)
+      Hreplay2
+      (OrchardCompiledAlgebraic.orchard_algebraic_mock_accepts
+        advice2 instance2 grid2 Es2 Hreplay2 Hcanon2 Haccepts2)
+      Hinputs Hdef).
+  Qed.
+
+  (** ** The operational bundle package
+
+      [OrchardBundleSpec.action_ok] ([bundle/spec.v]) is circuit
+      satisfaction plus the two short-lookup families the per-action
+      balance fact needs; both are discharged from acceptance of the
+      pinned circuit, so an accepted action satisfies the package
+      outright.  Stated here rather than under
+      [bundle/] so that the bundle layer keeps its lean dependency
+      closure. *)
+
+  Corollary action_ok_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    circuit_holds (realize Index.indices region_start_of grid)
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty) /\
+    NoteCommitNewWords.note_commit_new_short_lookup_ok
+      (realize Index.indices region_start_of grid) /\
+    OldNoteWords.old_note_short_lookup_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    exact (conj (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      (conj
+        (OrchardShortLookupClosure.note_commit_new_short_lookup_ok_operational
+          advice instance_ grid Hreplay Hmock)
+        (OrchardOldNoteLookupClosure.old_note_short_lookup_ok_operational
+          advice instance_ grid Hreplay Hmock))).
+  Qed.
+End OrchardAdversarialAction.

--- a/Garden/Orchard/circuit_proof/adversarial.v
+++ b/Garden/Orchard/circuit_proof/adversarial.v
@@ -1,0 +1,632 @@
+(** * The assembled adversarial Action statement
+
+    §4.18.4 'Action Statement (Orchard)' of the Zcash protocol
+    specification ([docs/protocol.pdf]), in the form the protocol itself
+    states it: four of the clauses disjunctively, with the ⊥ member of the
+    disjunction carried by the option-valued spec variants of
+    [circuit_proof/protocol_spec_bot.v], the other five public outputs as
+    exact equalities, and the whole input-typing surface conjoined.
+
+    The three track files discharge the four disjunctive clauses from
+    circuit acceptance alone ([circuit_proof/merkle_bot.v],
+    [circuit_proof/note_commit_bot.v], [circuit_proof/ownership_bot.v]);
+    this file adds the ⊥-free output equalities and the typing surface,
+    and assembles [OrchardAdversarialApi.adversarial_action_conclusion].
+
+    What is *not* a hypothesis, in contrast with
+    [OrchardAction.action_statement] ([circuit_proof/main.v]): the Merkle
+    package, the two note-commitment nondegeneracy conditions, the
+    [Commit^ivk] nondegeneracy, and the variable-base mul chip's
+    nondegeneracy.  What remains: circuit acceptance, the external typing
+    interface [OrchardAdversarialApi.WellTypedInstance] (facts belonging to
+    transaction decoding or consensus, never to the circuit), and the four
+    short-lookup range families — model artifacts of the relational
+    selector plane ([docs/chip-model-caveats.md]), discharged at the
+    acceptance levels in [circuit_adversarial.v].
+
+    The typing surface is circuit-derived throughout.  The five points
+    §4.18.4 requires to be non-identity ([g_d^old], [ak_P], [pk_d^old],
+    [g_d^new], [pk_d^new]) are witnessed through the
+    [Selector.QWitnessPointNonId] gate, whose single constraint is the
+    unconditional curve equation; no Pallas point has [x = 0]
+    ([EccSpec.pallas_curve_x_nonzero]), so non-identity follows.  [cm^old]
+    is witnessed through the plain [Selector.QWitnessPoint] gate, whose
+    disjunctive constraint gives on-curve or the identity sentinel —
+    matching the protocol's [cm^old : P].
+
+    Anti-blowup discipline ([docs/compile-performance.md]): every bridge
+    onto the protocol action spec is stated over *variable* parameters and
+    inputs, so no unification ever compares two sides differing underneath
+    a [sinsemilla_hash_to_point] or Poseidon application; the assembly is
+    [conj] term composition. *)
+
+Require Import Stdlib.Bool.Bool.
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.micromega.Lia.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.PallasModel.
+Require Import Garden.EllipticCurve.Pallas.
+Require Import Garden.EllipticCurve.PallasOrder.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.witness_point.
+Require Garden.Halo2.halo2_gadgets.utilities.cond_swap.
+Require Import Garden.Halo2.halo2_gadgets.utilities.cond_swap_proof.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.facts.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.merkle.
+Require Import Garden.Orchard.circuit_proof.fixed_base.main.
+Require Import Garden.Orchard.circuit_proof.protocol_equiv.
+Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
+Require Import Garden.Orchard.circuit_proof.typed_inputs.value64.
+Require Import Garden.Orchard.circuit_proof.typed_inputs.magnitude64.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+Require Import Garden.Orchard.circuit_proof.old_note.words.
+Require Import Garden.Orchard.circuit_proof.old_note.open.
+Require Import Garden.Orchard.circuit_proof.ownership.commit_ivk_hash.
+Require Import Garden.Orchard.circuit_proof.ownership.diversified_address.
+Require Import Garden.Orchard.circuit_proof.main.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial_api.
+Require Import Garden.Orchard.circuit_proof.note_commit_bot.
+Require Import Garden.Orchard.circuit_proof.ownership_bot.
+Require Import Garden.Orchard.circuit_proof.merkle_bot.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardAdversarial.
+  Import OrchardActionInputs.
+  Import OrchardProtocolSpecBot.
+  Import OrchardAdversarialApi.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** ** Record projections of the protocol action spec
+
+      Over VARIABLE parameters and inputs: both sides are the same
+      application, so neither the Sinsemilla folds nor the Poseidon round
+      chain is ever reduced. *)
+
+  Lemma out_cv_net_of_action_spec
+      (prm : OrchardSpec.Params) (inp : OrchardSpec.ActionInputs) :
+    OrchardSpec.out_cv_net
+      (OrchardProtocolSpec.orchard_action_spec prm inp) =
+    OrchardProtocolSpec.value_commit
+      (OrchardProtocolSpec.signed_net_value
+        (OrchardSpec.in_magnitude inp) (OrchardSpec.in_sign inp))
+      (OrchardSpec.in_rcv inp).
+  Proof. reflexivity. Qed.
+
+  Lemma out_rk_of_action_spec
+      (prm : OrchardSpec.Params) (inp : OrchardSpec.ActionInputs) :
+    OrchardSpec.out_rk
+      (OrchardProtocolSpec.orchard_action_spec prm inp) =
+    OrchardProtocolSpec.spend_auth_randomize
+      (OrchardSpec.in_ak inp) (OrchardSpec.in_alpha inp).
+  Proof. reflexivity. Qed.
+
+  Lemma point_eta (P : Point.t) :
+    {| Point.x := Point.x P; Point.y := Point.y P |} = P.
+  Proof. destruct P; reflexivity. Qed.
+
+  (** The public anchor row is itself an input: [read_action_inputs]
+      carries it as [in_anchor_public]. *)
+  Lemma in_anchor_public_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.in_anchor_public (read_action_inputs Γ) =
+      read_public_instance Γ Garden.Orchard.circuit.ANCHOR.
+  Proof. reflexivity. Qed.
+
+  (** ** The three ⊥-free output clauses
+
+      §4.18.4 'Value commitment integrity', 'Nullifier integrity' and
+      'Spend authority' use complete addition and total group multiples
+      only, so the protocol states them — and the circuit satisfies them —
+      as equalities, with acceptance the only hypothesis. *)
+
+  Lemma cv_net_output_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    cv_net_output_exact Γ.
+  Proof.
+    unfold cv_net_output_exact.
+    rewrite (OrchardAction.cv_net_x_correct Γ Hcircuit).
+    rewrite (OrchardAction.cv_net_y_correct Γ Hcircuit).
+    rewrite (OrchardNoteCommitBot.action_spec_protocol Γ Hcircuit).
+    rewrite (out_cv_net_of_action_spec orchard_circuit_params
+      (read_action_inputs Γ)).
+    apply point_eta.
+  Qed.
+
+  Lemma nf_old_output_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    nf_old_output_exact Γ.
+  Proof.
+    unfold nf_old_output_exact.
+    rewrite (OrchardAction.nf_old_correct Γ Hcircuit).
+    rewrite (OrchardNoteCommitBot.action_spec_protocol Γ Hcircuit).
+    exact (OrchardNoteCommitBot.out_nf_old_of_action_spec
+      orchard_circuit_params (read_action_inputs Γ)).
+  Qed.
+
+  Lemma rk_output_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    rk_output_exact Γ.
+  Proof.
+    unfold rk_output_exact.
+    rewrite (OrchardAction.rk_x_correct Γ Hcircuit).
+    rewrite (OrchardAction.rk_y_correct Γ Hcircuit).
+    rewrite (OrchardNoteCommitBot.action_spec_protocol Γ Hcircuit).
+    rewrite (out_rk_of_action_spec orchard_circuit_params
+      (read_action_inputs Γ)).
+    apply point_eta.
+  Qed.
+
+  (** ** Witnessed-point typing
+
+      §4.18.4: "Primary and auxiliary inputs MUST be constrained to have
+      the types specified.  In particular, g_d^old, pk_d^old, g_d^new,
+      pk_d^new, and ak_P cannot be 𝒪_P."  All five are constrained by the
+      circuit: the [Selector.QWitnessPointNonId] gate is the unconditional
+      curve equation, and no Pallas affine point has [x = 0], so the
+      identity sentinel [(0, 0)] is excluded. *)
+
+  Lemma wpoint_typed_of_curve_eqn
+      (Γ : Assignment.t columns RegionId.t) (region : RegionId.t)
+      (Hcurve :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.ecc.chip.witness_point
+            .curve_eqn Advice.A0 Advice.A1 ⟧ (region, 0) = 0) :
+    wpoint_typed (read_point Γ region).
+  Proof.
+    unfold Garden.Halo2.halo2_gadgets.ecc.chip.witness_point.curve_eqn,
+      Garden.Halo2.halo2_gadgets.utilities.square in Hcurve.
+    cbn [Evaluation.eval ExpressionIsEvaluable eval_expression rotated_row
+      Rotation.cur] in Hcurve.
+    change (rotated_row 0 Rotation.cur) with 0 in Hcurve.
+    assert (Hb_red :
+      UnOp.from Garden.Halo2.halo2_gadgets.ecc.chip.constants.pallas_b
+        = Garden.Halo2.halo2_gadgets.ecc.chip.constants.pallas_b)
+      by (vm_compute; reflexivity).
+    rewrite Hb_red in Hcurve.
+    set (x := UnOp.from (Γ.(Assignment.advice) Advice.A0 region 0)) in Hcurve.
+    set (y := UnOp.from (Γ.(Assignment.advice) Advice.A1 region 0)) in Hcurve.
+    pose proof (EccSpec.pallas_curve_x_nonzero x y Hcurve) as Hxnz.
+    assert (Hxr : UnOp.from x = x) by (subst x; apply FieldRewrite.from_from).
+    assert (Hxne : x <> 0) by (rewrite <- Hxr; exact Hxnz).
+    assert (Hpt : PallasModel.unrepr (read_point Γ region)
+        = Weierstrass.Weierstrass.Affine x y).
+    { unfold read_point, read, read1, read_advice, PallasModel.unrepr.
+      cbn [Evaluation.eval ExpressionIsEvaluable eval_expression
+        Point.x Point.y].
+      change (rotated_row 0 Rotation.cur) with 0.
+      fold x. fold y.
+      destruct (Z.eqb_spec x 0) as [E|E].
+      - exfalso. apply Hxne. exact E.
+      - cbn [andb]. reflexivity. }
+    unfold wpoint_typed.
+    rewrite Hpt.
+    refine (conj _ (conj _ _)).
+    - split; [exact Hxr | subst y; apply FieldRewrite.from_from].
+    - exact (PallasModel.affine_on_curve_of_poly x y Hcurve).
+    - intro Hid. discriminate Hid.
+  Qed.
+
+  (** The four remaining [QWitnessPointNonId] call sites of
+      [circuit.synthesize], reached by the layouter-fact navigation of
+      their binding positions ([g_d^old] is
+      [DiversifiedAddress.g_d_old_curve_eqn]). *)
+
+  Lemma ak_p_curve_eqn
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.ecc.chip.witness_point
+        .curve_eqn Advice.A0 Advice.A1 ⟧
+      (RegionId.WitnessInput RegionId.WitnessInput.AkP, 0) = 0.
+  Proof.
+    destruct Hcircuit as [Hfacts HSatisfies].
+    destruct HSatisfies as [Hgates Hlookups].
+    apply (OrchardActionFixedBase.witness_non_identity_point_on_curve Γ
+      (Garden.Orchard.circuit.witness_input_region RegionId.WitnessInput.AkP)
+      "witness ak_P").
+    - unfold Garden.Orchard.circuit.synthesize in Hfacts.
+      apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_witness_inputs in Hfacts.
+      do 4 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      exact Hfacts.
+    - exact Hgates.
+  Qed.
+
+  Lemma pk_d_old_curve_eqn
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.ecc.chip.witness_point
+        .curve_eqn Advice.A0 Advice.A1 ⟧
+      (RegionId.AddressIntegrity RegionId.AddressIntegrity.WitnessPkD, 0) = 0.
+  Proof.
+    destruct Hcircuit as [Hfacts HSatisfies].
+    destruct HSatisfies as [Hgates Hlookups].
+    apply (OrchardActionFixedBase.witness_non_identity_point_on_curve Γ
+      (Garden.Orchard.circuit.address_integrity_region
+        RegionId.AddressIntegrity.WitnessPkD)
+      "witness pk_d_old").
+    - unfold Garden.Orchard.circuit.synthesize in Hfacts.
+      do 7 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_address_integrity in Hfacts.
+      do 4 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      exact Hfacts.
+    - exact Hgates.
+  Qed.
+
+  Lemma g_d_new_curve_eqn
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.ecc.chip.witness_point
+        .curve_eqn Advice.A0 Advice.A1 ⟧
+      (RegionId.NoteCommitNewWitnessGD, 0) = 0.
+  Proof.
+    destruct Hcircuit as [Hfacts HSatisfies].
+    destruct HSatisfies as [Hgates Hlookups].
+    apply (OrchardActionFixedBase.witness_non_identity_point_on_curve Γ
+      RegionId.NoteCommitNewWitnessGD "witness g_d_new_star").
+    - unfold Garden.Orchard.circuit.synthesize in Hfacts.
+      do 9 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_note_commit_new in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      exact Hfacts.
+    - exact Hgates.
+  Qed.
+
+  Lemma pk_d_new_curve_eqn
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.ecc.chip.witness_point
+        .curve_eqn Advice.A0 Advice.A1 ⟧
+      (RegionId.NoteCommitNewWitnessPkD, 0) = 0.
+  Proof.
+    destruct Hcircuit as [Hfacts HSatisfies].
+    destruct HSatisfies as [Hgates Hlookups].
+    apply (OrchardActionFixedBase.witness_non_identity_point_on_curve Γ
+      RegionId.NoteCommitNewWitnessPkD "witness pk_d_new").
+    - unfold Garden.Orchard.circuit.synthesize in Hfacts.
+      do 9 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_note_commit_new in Hfacts.
+      apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      exact Hfacts.
+    - exact Hgates.
+  Qed.
+
+  (** [cm^old] is witnessed by the plain [Selector.QWitnessPoint] gate,
+      whose constraint is [x = 0 ∨ on_curve] together with
+      [y = 0 ∨ on_curve]: on-curve or the identity sentinel, which is
+      §4.18.4's [cm^old : P]. *)
+  Lemma cm_old_typed_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    OrchardSpec.in_cm_old (read_action_inputs Γ) = EccSpec.identity \/
+    wpoint_typed (OrchardSpec.in_cm_old (read_action_inputs Γ)).
+  Proof.
+    assert (Hcm : OrchardSpec.in_cm_old (read_action_inputs Γ) =
+        read_point Γ (RegionId.WitnessInput RegionId.WitnessInput.CmOld))
+      by reflexivity.
+    rewrite Hcm.
+    destruct Hcircuit as [Hfacts HSatisfies].
+    destruct HSatisfies as [Hgates Hlookups].
+    assert (Hpt : interpret_facts Γ (layouter_facts
+        (Garden.Orchard.circuit.witness_point
+          (Garden.Orchard.circuit.witness_input_region
+            RegionId.WitnessInput.CmOld) "cm_old"))).
+    { unfold Garden.Orchard.circuit.synthesize in Hfacts.
+      apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_witness_inputs in Hfacts.
+      do 2 apply interpret_layouter_facts_bind_right in Hfacts.
+      apply interpret_layouter_facts_bind_left in Hfacts.
+      exact Hfacts. }
+    destruct (OrchardActionFixedBase.witness_point_sound Γ
+      (Garden.Orchard.circuit.witness_input_region
+        RegionId.WitnessInput.CmOld)
+      "cm_old" Hpt Hgates) as [ [Hx Hy] | Hcurve ].
+    - left.
+      unfold read_point, read, read1, read_advice, EccSpec.identity.
+      f_equal; assumption.
+    - right. exact (wpoint_typed_of_curve_eqn Γ _ Hcurve).
+  Qed.
+
+  (** ** Merkle position-bit booleanity
+
+      The cond-swap gate of each layer's [NodePosition] region constrains
+      the swap cell to a boolean ([CondSwap.swap_is_bool]), so the
+      [merkle_swap_at] decode of [OrchardAdversarialApi.anchor_path_tracks]
+      is a faithful reading of the §4.9 authentication path. *)
+
+  Lemma is_bool_z (z : Z) (H : IsBool.ZIsBool.(IsBool.t) z) :
+    z = 0 \/ z = 1.
+  Proof.
+    cbn in H. destruct (Z.odd z); [right | left]; exact H.
+  Qed.
+
+  Lemma merkle_layer_facts_at
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ)
+      (i : nat) (Hi : (i < 32)%nat) :
+    interpret_facts Γ (layouter_facts
+      (Garden.Orchard.circuit.synthesize_merkle_layer (Z.of_nat i)
+        (merkle_node_cell i))).
+  Proof.
+    pose proof (OrchardActionFacts.merkle_path_facts Γ Hcircuit) as Hpath.
+    change (interpret_facts Γ
+      (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_path
+          OrchardActionMerkle.cm_old_x_cell))) in Hpath.
+    unfold Garden.Orchard.circuit.synthesize_merkle_path in Hpath.
+    apply interpret_layouter_facts_in_namespace in Hpath.
+    pose proof (OrchardMerkleBot.layers_facts Γ 32%nat 0
+      OrchardActionMerkle.cm_old_x_cell Hpath i Hi) as Hf.
+    change (0 + Z.of_nat i) with (Z.of_nat i) in Hf.
+    rewrite (OrchardMerkleBot.merkle_node_cell_eq i).
+    exact Hf.
+  Qed.
+
+  Lemma merkle_swap_bits_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    merkle_swap_bits_boolean Γ.
+  Proof.
+    intros i Hi.
+    pose proof (OrchardActionFixedBase.holds_gates Γ Hcircuit) as Hgates.
+    assert (Hz : i = Z.of_nat (Z.to_nat i)) by lia.
+    pose proof (merkle_layer_facts_at Γ Hcircuit (Z.to_nat i)
+      ltac:(lia)) as Hfacts.
+    rewrite <- Hz in Hfacts.
+    unfold merkle_swap_cell, merkle_node_position.
+    unfold Garden.Orchard.circuit.synthesize_merkle_layer in Hfacts.
+    destruct (i <? 16) eqn:Hlt.
+    - apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_node_position_1,
+        Garden.Orchard.circuit.synthesize_node_position_instance in Hfacts.
+      apply interpret_layouter_facts_in_namespace in Hfacts.
+      apply interpret_layouter_facts_add_region in Hfacts.
+      cbn [region_facts region_value Monad.bind Monad.ret
+        Garden.Halo2.Synthesis.RegionIsMonad List.app
+        interpret_facts interpret_fact] in Hfacts.
+      destruct Hfacts as (HselNP & _ & _).
+      apply is_bool_z.
+      exact (CondSwap.swap_is_bool Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+        Advice.A4
+        (enabled_nonzero Γ Selector.QCondSwap1 _ 0 HselNP)
+        (satisfies_gates_at Γ
+          (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+          (Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+            Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+            Advice.A4)
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.NodePosition)
+          0
+          ltac:(cbn; repeat (first [left; reflexivity | right]))
+          Hgates)).
+    - apply interpret_layouter_facts_bind_left in Hfacts.
+      unfold Garden.Orchard.circuit.synthesize_node_position_2,
+        Garden.Orchard.circuit.synthesize_node_position_instance in Hfacts.
+      apply interpret_layouter_facts_in_namespace in Hfacts.
+      apply interpret_layouter_facts_add_region in Hfacts.
+      cbn [region_facts region_value Monad.bind Monad.ret
+        Garden.Halo2.Synthesis.RegionIsMonad List.app
+        interpret_facts interpret_fact] in Hfacts.
+      destruct Hfacts as (HselNP & _ & _).
+      apply is_bool_z.
+      exact (CondSwap.swap_is_bool Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+        Advice.A9
+        (enabled_nonzero Γ Selector.QCondSwap2 _ 0 HselNP)
+        (satisfies_gates_at Γ
+          (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+          (Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+            Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+            Advice.A9)
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.NodePosition)
+          0
+          ltac:(cbn; repeat (first [left; reflexivity | right]))
+          Hgates)).
+  Qed.
+
+  (** ** The conjoined typing surface
+
+      Every conjunct is circuit-derived on a satisfying assignment.  The
+      two 64-bit note-value bounds are the only ones needing a short-lookup
+      family; §4.18.4 asks for no [< r_P] bound on the full-width scalars
+      ("It is not checked that rcv < r_P or that rcm^old < r_P or that
+      rcm^new < r_P"), and the [8^85 = 2^255] window reconstruction bounds
+      are the circuit-granularity reading. *)
+
+  Theorem typed_inputs_extended_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hnew_short : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ)
+      (Hold_short : OldNoteWords.old_note_short_lookup_ok Γ) :
+    typed_inputs_extended Γ.
+  Proof.
+    unfold typed_inputs_extended.
+    refine (conj _ (conj _ (conj _ (conj _ (conj _ (conj _ (conj _
+      (conj _ (conj _ (conj _ (conj _ (conj _ (conj _ _))))))))))))).
+    - exact (OrchardValidActionInputs.protocol_typed_inputs_of_holds
+        Γ Hcircuit).
+    - exact (TypedInputsValue64.in_v_old_64 Γ Hcircuit Hold_short).
+    - exact (TypedInputsValue64.in_v_new_64 Γ Hcircuit Hnew_short).
+    - exact (TypedInputsMagnitude64.in_magnitude_range_64 Γ Hcircuit).
+    - exact (OldNoteOpen.read_rcm_old_range Γ Hcircuit).
+    - exact (DiversifiedAddress.read_rivk_range Γ Hcircuit).
+    - exact (wpoint_typed_of_curve_eqn Γ _
+        (DiversifiedAddress.g_d_old_curve_eqn Γ Hcircuit)).
+    - exact (wpoint_typed_of_curve_eqn Γ _ (ak_p_curve_eqn Γ Hcircuit)).
+    - exact (wpoint_typed_of_curve_eqn Γ _ (pk_d_old_curve_eqn Γ Hcircuit)).
+    - exact (wpoint_typed_of_curve_eqn Γ _ (g_d_new_curve_eqn Γ Hcircuit)).
+    - exact (wpoint_typed_of_curve_eqn Γ _ (pk_d_new_curve_eqn Γ Hcircuit)).
+    - exact (cm_old_typed_of_holds Γ Hcircuit).
+    - exact (DiversifiedAddress.base_point_order Γ Hcircuit).
+    - exact (merkle_swap_bits_of_holds Γ Hcircuit).
+  Qed.
+
+  (** ** The adversarial Action statement
+
+      The §4.18.4 clause set with no witness-honesty hypothesis: the four
+      disjunctive clauses from the track files, the three ⊥-free output
+      equalities, the four input-side gate clauses, and the typing surface.
+      [WellTypedInstance] carries the §4.18.4 typing of the decoded primary
+      input — the facts enforced by transaction decoding and consensus
+      rather than by the circuit; it is the interface under which the
+      conclusion is the protocol's clause set.
+
+      The remaining premises are the four short-lookup range families: the
+      relational selector model leaves the range-check lookup's
+      [q_running] free at the checked rows, so they are model artifacts
+      rather than assumptions about the witness, and
+      [circuit_adversarial.v] discharges all four from acceptance of the
+      pinned circuit. *)
+
+  Theorem action_statement_adversarial
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hwti : WellTypedInstance Γ)
+      (Hnew_short : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ)
+      (Hold_short : OldNoteWords.old_note_short_lookup_ok Γ)
+      (Hivk_short : CommitIvkHash.commit_ivk_short_lookup_ok Γ)
+      (Hmerkle_b : merkle_b_range_ok Γ) :
+    adversarial_action_conclusion Γ.
+  Proof.
+    unfold adversarial_action_conclusion.
+    refine (conj _ (conj _ (conj _ (conj _ (conj _ (conj _ (conj _
+      (conj _ (conj _ (conj _ (conj _ _))))))))))).
+    - exact (OrchardMerkleBot.anchor_obligation_of_holds Γ Hcircuit Hmerkle_b).
+    - exact (cv_net_output_of_holds Γ Hcircuit).
+    - exact (nf_old_output_of_holds Γ Hcircuit).
+    - exact (rk_output_of_holds Γ Hcircuit).
+    - exact (OrchardNoteCommitBot.cmx_obligation_of_holds
+        Γ Hcircuit Hnew_short).
+    - exact (OrchardValidActionInputs.value_balance_gate Γ Hcircuit).
+    - exact (OrchardValidActionInputs.enable_spend_flag Γ Hcircuit).
+    - exact (OrchardValidActionInputs.enable_output_flag Γ Hcircuit).
+    - exact (OrchardValidActionInputs.cross_address_restriction Γ Hcircuit).
+    - exact (OrchardNoteCommitBot.old_note_obligation_of_holds
+        Γ Hcircuit Hold_short).
+    - exact (OrchardOwnershipBot.diversified_address_obligation_of_holds
+        Γ Hcircuit Hivk_short).
+    - exact (typed_inputs_extended_of_holds
+        Γ Hcircuit Hnew_short Hold_short).
+  Qed.
+
+  Corollary action_statement_adversarial_ok :
+    action_statement_adversarial_claim.
+  Proof.
+    intros Γ Hcircuit Hwti Hnew_short Hold_short Hivk_short Hmerkle_b.
+    exact (action_statement_adversarial Γ Hcircuit Hwti
+      Hnew_short Hold_short Hivk_short Hmerkle_b).
+  Qed.
+
+  (** ** Determinism conditioned on inputs alone
+
+      Two satisfying assignments agreeing on [read_action_inputs], on which
+      the ⊥-carrying new-note commitment of those inputs is defined, agree
+      on every public output row.  The definedness side condition is a
+      predicate on the input record alone — that is what makes the
+      statement conditioned on inputs and nothing else; on the exceptional
+      branch §4.18.4 licenses the prover to choose [cm_x], so no
+      determinism statement can hold there.
+
+      The five ⊥-free output rows and the anchor need no side condition at
+      all: their three output clauses are exact from acceptance, and the
+      anchor row is itself an input. *)
+
+  Theorem deterministic_adversarial
+      (Γ1 Γ2 : Assignment.t columns RegionId.t)
+      (H1 : Holds Γ1) (H2 : Holds Γ2)
+      (Hnew1 : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ1)
+      (Hnew2 : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ2)
+      (Hinputs : read_action_inputs Γ1 = read_action_inputs Γ2)
+      (Hdef :
+        cmx_bot_of_inputs orchard_circuit_params (read_action_inputs Γ1) <>
+          None) :
+    forall row : Z,
+      row = Garden.Orchard.circuit.ANCHOR \/
+      row = Garden.Orchard.circuit.CV_NET_X \/
+      row = Garden.Orchard.circuit.CV_NET_Y \/
+      row = Garden.Orchard.circuit.NF_OLD \/
+      row = Garden.Orchard.circuit.RK_X \/
+      row = Garden.Orchard.circuit.RK_Y \/
+      row = Garden.Orchard.circuit.CMX ->
+      read_public_instance Γ1 row = read_public_instance Γ2 row.
+  Proof.
+    (* The anchor row is an input. *)
+    assert (Eanchor : read_public_instance Γ1 Garden.Orchard.circuit.ANCHOR =
+        read_public_instance Γ2 Garden.Orchard.circuit.ANCHOR).
+    { rewrite <- (in_anchor_public_read Γ1), <- (in_anchor_public_read Γ2).
+      rewrite Hinputs. reflexivity. }
+    (* The value commitment. *)
+    pose proof (cv_net_output_of_holds Γ1 H1) as Ecv1.
+    pose proof (cv_net_output_of_holds Γ2 H2) as Ecv2.
+    unfold cv_net_output_exact in Ecv1, Ecv2.
+    rewrite Hinputs in Ecv1.
+    rewrite <- Ecv2 in Ecv1.
+    (* The nullifier. *)
+    pose proof (nf_old_output_of_holds Γ1 H1) as Enf1.
+    pose proof (nf_old_output_of_holds Γ2 H2) as Enf2.
+    unfold nf_old_output_exact in Enf1, Enf2.
+    rewrite Hinputs in Enf1.
+    rewrite <- Enf2 in Enf1.
+    (* The randomized spend-authority key. *)
+    pose proof (rk_output_of_holds Γ1 H1) as Erk1.
+    pose proof (rk_output_of_holds Γ2 H2) as Erk2.
+    unfold rk_output_exact in Erk1, Erk2.
+    rewrite Hinputs in Erk1.
+    rewrite <- Erk2 in Erk1.
+    (* The new-note commitment, on the defined branch of the clause. *)
+    assert (Ecmx : read_public_instance Γ1 Garden.Orchard.circuit.CMX =
+        read_public_instance Γ2 Garden.Orchard.circuit.CMX).
+    { destruct (OrchardNoteCommitBot.cmx_obligation_of_holds Γ1 H1 Hnew1)
+        as [Hnone | Hs1]; [exfalso; exact (Hdef Hnone) |].
+      destruct (OrchardNoteCommitBot.cmx_obligation_of_holds Γ2 H2 Hnew2)
+        as [Hnone | Hs2].
+      { exfalso. apply Hdef. rewrite Hinputs. exact Hnone. }
+      rewrite Hinputs in Hs1.
+      injection (eq_trans (eq_sym Hs1) Hs2) as Hrow.
+      exact Hrow. }
+    intros row Hrow.
+    destruct Hrow as [E | Hrow]; [subst row; exact Eanchor |].
+    destruct Hrow as [E | Hrow];
+      [subst row; exact (f_equal Point.x Ecv1) |].
+    destruct Hrow as [E | Hrow];
+      [subst row; exact (f_equal Point.y Ecv1) |].
+    destruct Hrow as [E | Hrow]; [subst row; exact Enf1 |].
+    destruct Hrow as [E | Hrow];
+      [subst row; exact (f_equal Point.x Erk1) |].
+    destruct Hrow as [E | E]; subst row;
+      [exact (f_equal Point.y Erk1) | exact Ecmx].
+  Qed.
+
+  Corollary deterministic_adversarial_ok :
+    deterministic_adversarial_claim.
+  Proof.
+    intros Γ1 Γ2 H1 H2 Hnew1 Hnew2 Hinputs Hdef.
+    exact (deterministic_adversarial Γ1 Γ2 H1 H2 Hnew1 Hnew2 Hinputs Hdef).
+  Qed.
+End OrchardAdversarial.

--- a/Garden/Orchard/circuit_proof/adversarial_api.v
+++ b/Garden/Orchard/circuit_proof/adversarial_api.v
@@ -32,6 +32,7 @@
 
 Require Import Stdlib.Lists.List.
 Require Import Stdlib.ZArith.ZArith.
+Require Import Stdlib.micromega.Lia.
 Require Import Garden.Halo2.main.
 Require Import Garden.Halo2.Synthesis.
 Require Import Garden.Halo2.proof.
@@ -514,27 +515,80 @@ Module OrchardAdversarialApi.
       never an injectivity or independence axiom.  Nothing here is proved
       or assumed by the adversarial statement itself. *)
 
+  (** The Sinsemilla generator domain: the [sinsemilla_s] table carries
+      one generator [S(j)] per [k]-bit word, [0 <= j < 2^k].  Outside
+      this range the total lookup reads the [(0, 0)] sentinel, which
+      [PallasModel.unrepr] maps to the group identity — so an
+      out-of-range index names no generator at all. *)
+  Definition sinsemilla_generator_count : Z :=
+    2 ^ SinsemillaSpec.sinsemilla_k.
+  #[local] Arguments sinsemilla_generator_count : simpl never.
+
   (** A linear combination of the Sinsemilla domain point and table
-      generators: [c0]·[Q] plus [Σ c·S(j)] over the listed [(j, c)]
-      pairs, in the Pallas group. *)
+      generators, in canonical form: [c0]·[Q] plus [Σ c(j)·S(j)] over
+      the whole generator domain, in the Pallas group.  The coefficient
+      function assigns each generator exactly one aggregate coefficient,
+      and indices outside the domain contribute nothing. *)
   Definition sinsemilla_generator_combination
-      (Q : Point.t) (c0 : Z) (cs : list (Z * Z)) : Pallas.point :=
+      (Q : Point.t) (c0 : Z) (c : Z -> Z) : Pallas.point :=
     Stdlib.Lists.List.fold_left
-      (fun acc jc =>
+      (fun acc j =>
         Pallas.add acc
-          (Pallas.mul (snd jc)
-            (PallasModel.unrepr (SinsemillaSpec.generator (fst jc)))))
-      cs
+          (Pallas.mul (c j)
+            (PallasModel.unrepr (SinsemillaSpec.generator j))))
+      (List.map Z.of_nat (List.seq 0 (Z.to_nat sinsemilla_generator_count)))
       (Pallas.mul c0 (PallasModel.unrepr Q)).
 
   (** A nontrivial discrete-logarithm relation among [Q] and the [S(j)]:
-      the combination vanishes while not every coefficient vanishes
-      mod the group order. *)
+      the combination vanishes while some canonical coefficient — [c0],
+      or [c j] with [j] in the generator domain — is nonzero mod the
+      group order.  Nontriviality quantifies over the canonical
+      coefficients only, so a coefficient supported outside the domain
+      neither feeds the combination nor counts as nontrivial, and
+      cancelling contributions to one generator carry no weight: the
+      relation holds exactly when a genuinely nontrivial linear identity
+      among [Q] and the [2^k] distinct generators is exhibited. *)
   Definition sinsemilla_dlog_relation
-      (Q : Point.t) (c0 : Z) (cs : list (Z * Z)) : Prop :=
-    sinsemilla_generator_combination Q c0 cs = Pallas.identity /\
+      (Q : Point.t) (c0 : Z) (c : Z -> Z) : Prop :=
+    sinsemilla_generator_combination Q c0 c = Pallas.identity /\
     ~ (c0 mod Pallas.pallas_q = 0 /\
-       List.Forall (fun jc => snd jc mod Pallas.pallas_q = 0) cs).
+       forall j : Z, 0 <= j < sinsemilla_generator_count ->
+         c j mod Pallas.pallas_q = 0).
+
+  (** Aggregate coefficient view of a sparse [(index, coefficient)] pair
+      list: the summed coefficient a generator index receives.  The
+      regression lemmas below state the relation through this view on
+      the two degenerate sparse witnesses — an out-of-table index and a
+      cancelling pair — and reject both. *)
+  Definition sparse_coefficient (cs : list (Z * Z)) (j : Z) : Z :=
+    Stdlib.Lists.List.fold_left
+      (fun s jc => if fst jc =? j then s + snd jc else s) cs 0.
+
+  (** A coefficient placed at the out-of-table index [2^k] aggregates to
+      the zero coefficient function on the generator domain, hence
+      exhibits no relation. *)
+  Lemma sparse_out_of_range_rejected (Q : Point.t) :
+    ~ sinsemilla_dlog_relation Q 0
+        (sparse_coefficient [(sinsemilla_generator_count, 1)]).
+  Proof.
+    intros [_ Hnontrivial].
+    apply Hnontrivial; split; [reflexivity |].
+    intros j Hj; unfold sparse_coefficient; cbn.
+    destruct (Z.eqb_spec sinsemilla_generator_count j);
+      [exfalso; lia | reflexivity].
+  Qed.
+
+  (** Two occurrences of one generator with cancelling coefficients
+      aggregate to the zero coefficient function, hence exhibit no
+      relation. *)
+  Lemma sparse_cancellation_rejected (Q : Point.t) (j : Z) :
+    ~ sinsemilla_dlog_relation Q 0 (sparse_coefficient [(j, 1); (j, -1)]).
+  Proof.
+    intros [_ Hnontrivial].
+    apply Hnontrivial; split; [reflexivity |].
+    intros k _; unfold sparse_coefficient; cbn.
+    destruct (Z.eqb_spec j k); reflexivity.
+  Qed.
 
   (** Theorem 5.4.3 as a named reduction hypothesis: a fixed-length
       collision of the ⊥-carrying hash-to-point yields a relation. *)
@@ -545,8 +599,8 @@ Module OrchardAdversarialApi.
       sinsemilla_hash_to_point_bot Q ws =
         sinsemilla_hash_to_point_bot Q ws' ->
       sinsemilla_hash_to_point_bot Q ws <> None ->
-      exists (c0 : Z) (cs : list (Z * Z)),
-        sinsemilla_dlog_relation Q c0 cs.
+      exists (c0 : Z) (c : Z -> Z),
+        sinsemilla_dlog_relation Q c0 c.
 
   (** Theorem 5.4.4 as a named reduction hypothesis: a ⊥ output of the
       hash-to-point yields a relation (the exceptional operand pair is a
@@ -555,8 +609,8 @@ Module OrchardAdversarialApi.
   Definition SinsemillaExceptionalDlogReduction : Prop :=
     forall (Q : Point.t) (ws : list Z),
       sinsemilla_hash_to_point_bot Q ws = None ->
-      exists (c0 : Z) (cs : list (Z * Z)),
-        sinsemilla_dlog_relation Q c0 cs.
+      exists (c0 : Z) (c : Z -> Z),
+        sinsemilla_dlog_relation Q c0 c.
 
   (** Statement only — no proof is attempted in this development.  Under
       the Theorem 5.4.4 reduction, [anchor_obligation]'s §4.9 escape
@@ -575,8 +629,8 @@ Module OrchardAdversarialApi.
       Holds Γ ->
       merkle_b_range_ok Γ ->
       OrchardSpec.in_v_old (read_action_inputs Γ) = 0 \/
-      (exists (c0 : Z) (cs : list (Z * Z)),
-         sinsemilla_dlog_relation OrchardActionMerkle.merkle_Q c0 cs) \/
+      (exists (c0 : Z) (c : Z -> Z),
+         sinsemilla_dlog_relation OrchardActionMerkle.merkle_Q c0 c) \/
       anchor_path_tracks Γ.
 
 End OrchardAdversarialApi.

--- a/Garden/Orchard/circuit_proof/adversarial_api.v
+++ b/Garden/Orchard/circuit_proof/adversarial_api.v
@@ -1,0 +1,582 @@
+(** * The adversarial Action statement API
+
+    The per-output obligations of §4.18.4 'Action Statement (Orchard)' of
+    the Zcash protocol specification ([docs/protocol.pdf]) in their
+    disjunctive, witness-honesty-free form, and the statements of the
+    assembled adversarial Action theorem and its determinism corollary.
+    This file is the statement surface only: the obligations are proved
+    from circuit acceptance by the track files
+    ([circuit_proof/note_commit_bot.v], [circuit_proof/ownership_bot.v],
+    [circuit_proof/merkle_bot.v]) and assembled in
+    [circuit_proof/adversarial.v] / [circuit_adversarial.v].
+
+    The existing theorem surface ([circuit_proof/main.v],
+    [circuit_proof/valid_action_inputs.v]) states the §4.18.4 clauses as
+    exact equalities conditioned on nondegeneracy/canonicity hypotheses —
+    the protocol's non-⊥ branch.  The protocol itself states four clauses
+    disjunctively, sanctioning the circuit's incomplete-addition slack:
+    'Merkle path validity' (via the §4.9 escape), 'Old note commitment
+    integrity' ([∈ {cm_old, ⊥}]), 'New note commitment integrity'
+    ([∈ {cm_x, ⊥}]) and 'Diversified address integrity'
+    ([ivk = ⊥ ∨ pk_d = [ivk] g_d]).  The obligations below transcribe those
+    clauses over the ⊥-carrying spec variants
+    ([circuit_proof/protocol_spec_bot.v]); the other five public outputs
+    are ⊥-free and stay exact equalities.
+
+    Residual model-artifact hypotheses: the short-lookup range families
+    (the relational selector model leaves the range-check lookup's
+    [q_running] free, [docs/chip-model-caveats.md]) appear as hypotheses of
+    the relational statements and are discharged at the acceptance levels
+    by the lookup-closure files.  No nondegeneracy or canonicity hypothesis
+    appears anywhere. *)
+
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.PallasModel.
+Require Import Garden.EllipticCurve.Pallas.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.merkle.
+Require Import Garden.Orchard.circuit_proof.protocol_equiv.
+Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+Require Import Garden.Orchard.circuit_proof.old_note.words.
+Require Import Garden.Orchard.circuit_proof.ownership.commit_ivk_hash.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardAdversarialApi.
+  Import OrchardActionInputs.
+  Import OrchardProtocolSpecBot.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** ** Merkle path readers
+
+      The per-layer authentication-path cells, in the spelling of
+      [OrchardActionInputs.merkle_path_of] ([circuit_proof/inputs.v]): the
+      cond-swap layout reads the sibling on [A1]/[A6] and the position bit
+      on [A4]/[A9] of the layer's [NodePosition] region ([QCondSwap1] for
+      layers 0–15, [QCondSwap2] for 16–31). *)
+
+  Definition merkle_node_position (i : Z) : RegionId.t :=
+    RegionId.Merkle (RegionId.Merkle.Layer.of_index i)
+      RegionId.Merkle.Region.NodePosition.
+
+  Definition merkle_sibling_at
+      (Γ : Assignment.t columns RegionId.t) (i : Z) : Z :=
+    if i <? 16
+    then read1 Γ (merkle_node_position i)
+    else read6 Γ (merkle_node_position i).
+
+  Definition merkle_swap_cell
+      (Γ : Assignment.t columns RegionId.t) (i : Z) : Z :=
+    if i <? 16
+    then read4 Γ (merkle_node_position i)
+    else read9 Γ (merkle_node_position i).
+
+  Definition merkle_swap_at
+      (Γ : Assignment.t columns RegionId.t) (i : Z) : bool :=
+    merkle_swap_cell Γ i =? 1.
+
+  (** Booleanity of the 32 position bits — circuit-derived (the cond-swap
+      gate constrains the swap cell to a boolean,
+      [CondSwap.swap_is_bool]), conjoined by the adversarial statement so
+      the [merkle_swap_at] decode is a faithful reading of the §4.9 path
+      position. *)
+  Definition merkle_swap_bits_boolean
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    forall i : Z, 0 <= i < 32 ->
+      merkle_swap_cell Γ i = 0 \/ merkle_swap_cell Γ i = 1.
+
+  (** ** The running Merkle node cells
+
+      The cell chain [circuit.synthesize_merkle_path] threads: the
+      witnessed old-note-commitment x-cell at the leaf, then each layer's
+      hash output cell.  The recursion is a higher-order iterator over an
+      abstract step so the fixpoint body never mentions the synthesis
+      constants. *)
+
+  Fixpoint node_cell_iter
+      (step : Z -> Garden.Halo2.Synthesis.Cell.t columns RegionId.t ->
+        Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      (leaf : Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      (n : nat) : Garden.Halo2.Synthesis.Cell.t columns RegionId.t :=
+    match n with
+    | O => leaf
+    | S m => step (Z.of_nat m) (node_cell_iter step leaf m)
+    end.
+
+  Definition merkle_node_cell (n : nat)
+      : Garden.Halo2.Synthesis.Cell.t columns RegionId.t :=
+    node_cell_iter
+      (fun layer node =>
+        layouter_value
+          (Garden.Orchard.circuit.synthesize_merkle_layer layer node))
+      OrchardActionMerkle.cm_old_x_cell
+      n.
+
+  (** The node value carried after [n] layers: [Extract_P(cm_old)] at
+      [n = 0], then each layer's output cell, read reduced. *)
+  Definition merkle_node_at
+      (Γ : Assignment.t columns RegionId.t) (n : nat) : Z :=
+    UnOp.from (eval_cell Γ (merkle_node_cell n)).
+
+  (** ** Residual short-lookup hypothesis of the Merkle track
+
+      The 5-bit ranges of the [RangeB1]/[RangeB2] cells of every layer —
+      the [b_1]/[b_2] pieces of the decomposition.  Together they bound
+      the layer's [b_1 + b_2·2^5] reconstruction below [2^10 < p], the one
+      canonicity conjunct the witnessed-message identity of
+      [anchor_path_tracks] needs.  A short-lookup range family like the
+      note-commitment ones: free in the relational selector model,
+      discharged from operational acceptance by the [ShortSite] machinery
+      ([circuit_proof/lookup_closure.v]) in [circuit_proof/merkle_bot.v]. *)
+  Definition merkle_b_range_ok
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    forall i : Z, 0 <= i < 32 ->
+      0 <=
+        UnOp.from (eval_cell Γ
+          (Garden.Halo2.Synthesis.Cell.advice
+            (Garden.Orchard.circuit.merkle_region i
+              RegionId.Merkle.Region.RangeB1)
+            Advice.A9 0)) < 2 ^ 5 /\
+      0 <=
+        UnOp.from (eval_cell Γ
+          (Garden.Halo2.Synthesis.Cell.advice
+            (Garden.Orchard.circuit.merkle_region i
+              RegionId.Merkle.Region.RangeB2)
+            Advice.A9 0)) < 2 ^ 5.
+
+  (** ** Obligation: Merkle path validity (§4.18.4, adversarial reading)
+
+      §4.18.4: "Either v^old = 0; or (path, pos) is a valid Merkle path of
+      depth MerkleDepth^Orchard, as defined in section 4.9 'Merkle Path
+      Validity', from Extract_P(cm^old) to the anchor rt^OrchardPool."
+
+      [anchor_path_tracks] is the path-validity disjunct over the
+      *witnessed* per-layer messages: each layer's hashed 52-word message
+      is a [merkle_message] of some integer pair congruent mod [p] to the
+      running node and the witnessed sibling — not necessarily their
+      canonical 255-bit encodings.  The §4.18.4 note licenses exactly this:
+      "In the Merkle path validity check, each layer does not check that
+      its input bit sequence is a canonical encoding (in {0 .. q_P − 1}) of
+      the integer from the previous layer."  Under
+      [OrchardActionMerkle.merkle_witness_ok] the witnessed pair collapses
+      to the canonical one and the clause becomes the
+      [merkle_root_cell_correct] conclusion. *)
+  Definition anchor_path_tracks
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    (forall i : nat, (i < 32)%nat ->
+       Some (merkle_node_at Γ (S i)) =
+         sinsemilla_hash_bot OrchardActionMerkle.merkle_Q
+           (OrchardActionMerkle.merkle_words Γ (Z.of_nat i))) /\
+    (forall i : nat, (i < 32)%nat ->
+       exists left right : Z,
+         OrchardActionMerkle.merkle_words Γ (Z.of_nat i) =
+           SinsemillaSpec.merkle_message (Z.of_nat i) left right /\
+         UnOp.from left =
+           (if merkle_swap_at Γ (Z.of_nat i)
+            then merkle_sibling_at Γ (Z.of_nat i)
+            else merkle_node_at Γ i) /\
+         UnOp.from right =
+           (if merkle_swap_at Γ (Z.of_nat i)
+            then merkle_node_at Γ i
+            else merkle_sibling_at Γ (Z.of_nat i))) /\
+    merkle_node_at Γ 0%nat =
+      EccSpec.extract_x (OrchardSpec.in_cm_old (read_action_inputs Γ)) /\
+    merkle_node_at Γ 32%nat =
+      read_public_instance Γ Garden.Orchard.circuit.ANCHOR.
+
+  (** The full clause.  Disjunct 1 is §4.18.4's own "Either v^old = 0";
+      disjunct 2 is the §4.9 escape — "the validity check is permitted to
+      be implemented in such a way that it can pass if any hash value on
+      the path, including the root, is 0", which by §5.4.1.3
+      ([MerkleCRH^Orchard(…) := 0 if hash = ⊥]) happens exactly when that
+      layer's Sinsemilla fold is ⊥; disjunct 3 is path validity over the
+      witnessed messages.  There is no ⊥-carrying Merkle *root*: §5.4.1.3
+      makes [MerkleCRH^Orchard] total (⊥ ↦ 0) while the circuit's output
+      at an exceptional layer is an unconstrained prover value, so after a
+      first exception neither the true nor the witnessed root is tracked —
+      the escape is an existential over layers, not a root value. *)
+  Definition anchor_obligation
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    OrchardSpec.in_v_old (read_action_inputs Γ) = 0 \/
+    (exists i : nat, (i < 32)%nat /\
+       sinsemilla_hash_to_point_bot OrchardActionMerkle.merkle_Q
+         (OrchardActionMerkle.merkle_words Γ (Z.of_nat i)) = None) \/
+    anchor_path_tracks Γ.
+
+  (** ** Obligation: new note commitment integrity (§4.18.4)
+
+      "Extract⊥_P(NoteCommit^Orchard_rcm_new(g⋆_d_new, pk⋆_d_new, v_new,
+      ρ_new, ψ_new)) ∈ {cm_x, ⊥}" with [ρ_new = nf_old].  The commitment
+      is a function of the input record alone — [ρ_new] is the (total)
+      nullifier of the old-note inputs — which is what makes
+      [deterministic_adversarial_claim] conditioned on inputs only. *)
+  Definition cmx_bot_of_inputs
+      (prm : OrchardSpec.Params) (inp : OrchardSpec.ActionInputs)
+      : option Z :=
+    OrchardCmx_bot prm
+      (OrchardSpec.in_g_d_new inp)
+      (OrchardSpec.in_pk_d_new inp)
+      (OrchardSpec.in_v_new inp)
+      (OrchardProtocolSpec.nullifier
+        (OrchardSpec.in_nk inp) (OrchardSpec.in_rho_old inp)
+        (OrchardSpec.in_psi_old inp) (OrchardSpec.in_cm_old inp))
+      (OrchardSpec.in_psi_new inp)
+      (OrchardSpec.in_rcm_new inp).
+
+  Definition cmx_obligation (Γ : Assignment.t columns RegionId.t) : Prop :=
+    cmx_bot_of_inputs orchard_circuit_params (read_action_inputs Γ) = None \/
+    cmx_bot_of_inputs orchard_circuit_params (read_action_inputs Γ) =
+      Some (read_public_instance Γ Garden.Orchard.circuit.CMX).
+
+  (** ** Obligation: old note commitment integrity (§4.18.4)
+
+      "NoteCommit^Orchard_rcm_old(g⋆_d_old, pk⋆_d_old, v_old, ρ_old,
+      ψ_old) ∈ {cm_old, ⊥}" — the literal protocol clause, over the
+      ownership-track readers of [circuit_proof/valid_action_inputs.v]. *)
+  Definition old_note_bot_of
+      (Γ : Assignment.t columns RegionId.t) : option Point.t :=
+    note_commit_bot orchard_circuit_params
+      (OrchardSpec.in_g_d_old (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_pk_d_old Γ)
+      (OrchardSpec.in_v_old (read_action_inputs Γ))
+      (OrchardSpec.in_rho_old (read_action_inputs Γ))
+      (OrchardSpec.in_psi_old (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_rcm_old Γ).
+
+  Definition old_note_obligation
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    old_note_bot_of Γ = None \/
+    old_note_bot_of Γ =
+      Some (OrchardSpec.in_cm_old (read_action_inputs Γ)).
+
+  (** ** Obligation: diversified address integrity (§4.18.4)
+
+      "ivk = ⊥ or pk_d^old = [ivk] g_d^old" with
+      [ivk = Commit^ivk_rivk(ak, nk)].  The ⊥ belongs to the [Commit^ivk]
+      Sinsemilla fold only; the protocol grants the variable-base
+      multiplication no exceptional escape (its p.67 note *requires* the
+      [ivk] decomposition to be canonical), so on the tracking branch the
+      multiplication holds exactly — the mul chip's nondegeneracy is
+      derived from the gates by the ownership track, never disjuncted. *)
+  Definition commit_ivk_bot_of
+      (Γ : Assignment.t columns RegionId.t) : option Z :=
+    commit_ivk_bot orchard_circuit_params
+      (EccSpec.extract_x (OrchardSpec.in_ak (read_action_inputs Γ)))
+      (OrchardSpec.in_nk (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_rivk Γ).
+
+  Definition diversified_address_obligation
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    commit_ivk_bot_of Γ = None \/
+    (exists ivk : Z,
+       commit_ivk_bot_of Γ = Some ivk /\
+       OrchardValidActionInputs.read_pk_d_old Γ =
+         PallasModel.repr
+           (Pallas.mul ivk
+             (PallasModel.unrepr
+               (OrchardSpec.in_g_d_old (read_action_inputs Γ))))).
+
+  (** ** The five ⊥-free outputs — exact equalities
+
+      Spend authority, value commitment integrity and nullifier integrity
+      use complete addition and total group multiples only (§4.18.4 with
+      §5.4.7.1 / §5.4.8.3 / §4.16); the protocol states them as equalities
+      and so does the adversarial statement. *)
+
+  Definition cv_net_output_exact
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    {| Point.x := read_public_instance Γ Garden.Orchard.circuit.CV_NET_X;
+       Point.y := read_public_instance Γ Garden.Orchard.circuit.CV_NET_Y |} =
+    OrchardProtocolSpec.value_commit
+      (OrchardProtocolSpec.signed_net_value
+        (OrchardSpec.in_magnitude (read_action_inputs Γ))
+        (OrchardSpec.in_sign (read_action_inputs Γ)))
+      (OrchardSpec.in_rcv (read_action_inputs Γ)).
+
+  Definition nf_old_output_exact
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    read_public_instance Γ Garden.Orchard.circuit.NF_OLD =
+    OrchardProtocolSpec.nullifier
+      (OrchardSpec.in_nk (read_action_inputs Γ))
+      (OrchardSpec.in_rho_old (read_action_inputs Γ))
+      (OrchardSpec.in_psi_old (read_action_inputs Γ))
+      (OrchardSpec.in_cm_old (read_action_inputs Γ)).
+
+  Definition rk_output_exact
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    {| Point.x := read_public_instance Γ Garden.Orchard.circuit.RK_X;
+       Point.y := read_public_instance Γ Garden.Orchard.circuit.RK_Y |} =
+    OrchardProtocolSpec.spend_auth_randomize
+      (OrchardSpec.in_ak (read_action_inputs Γ))
+      (OrchardSpec.in_alpha (read_action_inputs Γ)).
+
+  (** ** The conjoined typing surface
+
+      §4.18.4: "Primary and auxiliary inputs MUST be constrained to have
+      the types specified. In particular, g_d^old, pk_d^old, g_d^new,
+      pk_d^new, and ak_P cannot be 𝒪_P."  Everything below is
+      circuit-derived on a satisfying assignment — the five listed points
+      through the unconditional [QWitnessPointNonId] curve-equation gate
+      (non-identity because no Pallas point has [x = 0]), [cm_old] through
+      the plain [QWitnessPoint] gate (on-curve or the identity sentinel,
+      matching [cm^old : P]), the scalar ranges through the running-sum
+      window bounds, and the 64-bit note values through the short-lookup
+      families.  §4.18.4 does not ask for [< r_P] on the full-width
+      scalars ("It is not checked that rcv < r_P or that rcm^old < r_P or
+      that rcm^new < r_P"); the [8^85 = 2^255] window bounds are the
+      circuit-granularity reading. *)
+
+  (** A reduced affine on-curve non-identity Pallas point, at the
+      represented (Weierstrass) reading of an affine coordinate record. *)
+  Definition wpoint_typed (P : Point.t) : Prop :=
+    Pallas.reduced (PallasModel.unrepr P) /\
+    Pallas.on_curve (PallasModel.unrepr P) /\
+    PallasModel.unrepr P <> Pallas.identity.
+
+  Definition typed_inputs_extended
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    OrchardProtocolEquiv.ProtocolTypedInputs (read_action_inputs Γ) /\
+    0 <= OrchardSpec.in_v_old (read_action_inputs Γ) < 2 ^ 64 /\
+    0 <= OrchardSpec.in_v_new (read_action_inputs Γ) < 2 ^ 64 /\
+    0 <= OrchardSpec.in_magnitude (read_action_inputs Γ) < 2 ^ 64 /\
+    0 <= OrchardValidActionInputs.read_rcm_old Γ < 8 ^ 85 /\
+    0 <= OrchardValidActionInputs.read_rivk Γ < 8 ^ 85 /\
+    wpoint_typed (OrchardSpec.in_g_d_old (read_action_inputs Γ)) /\
+    wpoint_typed (OrchardSpec.in_ak (read_action_inputs Γ)) /\
+    wpoint_typed (OrchardValidActionInputs.read_pk_d_old Γ) /\
+    wpoint_typed (OrchardSpec.in_g_d_new (read_action_inputs Γ)) /\
+    wpoint_typed (OrchardSpec.in_pk_d_new (read_action_inputs Γ)) /\
+    (OrchardSpec.in_cm_old (read_action_inputs Γ) = EccSpec.identity \/
+     wpoint_typed (OrchardSpec.in_cm_old (read_action_inputs Γ))) /\
+    Pallas.mul Pallas.pallas_q
+      (PallasModel.unrepr (OrchardSpec.in_g_d_old (read_action_inputs Γ))) =
+      Pallas.identity /\
+    merkle_swap_bits_boolean Γ.
+
+  (** ** [WellTypedInstance] — the external typing premise
+
+      Exactly the §4.18.4 typing facts that transaction decoding or
+      consensus enforces and the circuit does not; everything the circuit
+      does enforce is conjoined by [typed_inputs_extended] rather than
+      assumed.  Row 9 ([DISABLE_CROSS_ADDRESS]) carries no member on
+      purpose: [OrchardValidActionInputs.cross_address_restriction] is
+      proved for zero against every nonzero value, which subsumes a
+      boolean reading. *)
+  Record WellTypedInstance
+      (Γ : Assignment.t columns RegionId.t) : Prop := {
+    (* §4.18.4 primary input [enableSpends : B].  The [QOrchard] gate
+       ("v_old = 0 or enable_spend = 1", [circuit.v]) forces the flag to 1
+       only when [v_old <> 0]; at [v_old = 0] the row is a free field
+       element.  Enforcement point: transaction decoding of the Action
+       description's flags. *)
+    wti_enable_spend_bool :
+      read_public_instance Γ Garden.Orchard.circuit.ENABLE_SPEND = 0 \/
+      read_public_instance Γ Garden.Orchard.circuit.ENABLE_SPEND = 1;
+
+    (* §4.18.4 primary input [enableOutputs : B]; the same asymmetry
+       through "v_new = 0 or enable_output = 1". *)
+    wti_enable_output_bool :
+      read_public_instance Γ Garden.Orchard.circuit.ENABLE_OUTPUT = 0 \/
+      read_public_instance Γ Garden.Orchard.circuit.ENABLE_OUTPUT = 1;
+
+    (* §4.18.4 note: "The case rk = 𝒪_P will not occur, due to the
+       consensus rule in section 4.6 'Action Descriptions' that rk MUST
+       NOT be the identity point."  Enforcement point: consensus. *)
+    wti_rk_non_identity :
+      ~ (read_public_instance Γ Garden.Orchard.circuit.RK_X = 0 /\
+         read_public_instance Γ Garden.Orchard.circuit.RK_Y = 0);
+
+    (* §4.18.4 note: the primary input is the sequence [rt, x(cv^net),
+       y(cv^net), nf^old, x(rk), y(rk), cm_x, enableSpends, enableOutputs]
+       (rows 0..8; row 9 the cross-address flag), each an F_{q_P} element.
+       The member records the decoded rows as already-reduced residues on
+       the raw instance plane (the model's evaluated reads reduce
+       unconditionally, so the raw plane is where the encoding assumption
+       has content).  Enforcement point: the Action-description encoding /
+       transaction decoding. *)
+    wti_instance_rows_reduced :
+      forall row : Z, 0 <= row < 10 ->
+        UnOp.from (Γ.(Assignment.instance_) Instance_.Primary row) =
+          Γ.(Assignment.instance_) Instance_.Primary row;
+  }.
+
+  (** ** The assembled adversarial conclusion
+
+      The §4.18.4 clause set with no witness-honesty hypotheses: the four
+      disjunctive clauses, the five exact outputs, the input-side gate
+      clauses (value balance, the two enable flags, the cross-address
+      restriction — verbatim the corresponding
+      [OrchardValidActionInputs.ValidActionInputs] conjuncts), and the
+      conjoined typing surface. *)
+  Definition adversarial_action_conclusion
+      (Γ : Assignment.t columns RegionId.t) : Prop :=
+    anchor_obligation Γ /\
+    cv_net_output_exact Γ /\
+    nf_old_output_exact Γ /\
+    rk_output_exact Γ /\
+    cmx_obligation Γ /\
+    (OrchardSpec.in_v_old (read_action_inputs Γ) -F
+       OrchardSpec.in_v_new (read_action_inputs Γ) =
+     OrchardSpec.in_magnitude (read_action_inputs Γ) *F
+       OrchardSpec.in_sign (read_action_inputs Γ)) /\
+    (OrchardSpec.in_v_old (read_action_inputs Γ) = 0 \/
+     read_public_instance Γ Garden.Orchard.circuit.ENABLE_SPEND = 1) /\
+    (OrchardSpec.in_v_new (read_action_inputs Γ) = 0 \/
+     read_public_instance Γ Garden.Orchard.circuit.ENABLE_OUTPUT = 1) /\
+    (read_public_instance Γ
+       Garden.Orchard.circuit.DISABLE_CROSS_ADDRESS = 0 \/
+     (OrchardSpec.in_g_d_old (read_action_inputs Γ) =
+        OrchardSpec.in_g_d_new (read_action_inputs Γ) /\
+      OrchardValidActionInputs.read_pk_d_old Γ =
+        OrchardSpec.in_pk_d_new (read_action_inputs Γ))) /\
+    old_note_obligation Γ /\
+    diversified_address_obligation Γ /\
+    typed_inputs_extended Γ.
+
+  (** The relational adversarial Action statement.  Premises: acceptance,
+      the external typing interface, and the residual short-lookup range
+      families (model artifacts, discharged at the acceptance levels by
+      the lookup-closure machinery).  [WellTypedInstance] carries the
+      §4.18.4 typing of the decoded primary input; no conclusion below
+      consumes it, and it is part of the statement as the interface under
+      which the conclusion set is the §4.18.4 clause set. *)
+  Definition action_statement_adversarial_claim : Prop :=
+    forall (Γ : Assignment.t columns RegionId.t),
+      Holds Γ ->
+      WellTypedInstance Γ ->
+      NoteCommitNewWords.note_commit_new_short_lookup_ok Γ ->
+      OldNoteWords.old_note_short_lookup_ok Γ ->
+      CommitIvkHash.commit_ivk_short_lookup_ok Γ ->
+      merkle_b_range_ok Γ ->
+      adversarial_action_conclusion Γ.
+
+  (** ** Determinism conditioned on inputs alone
+
+      Two satisfying assignments that agree on the input record and on
+      which the ⊥-carrying new-note commitment is defined agree on every
+      public output row.  Definedness is a predicate on the input record
+      ([cmx_bot_of_inputs] reads nothing but the record); no
+      nondegeneracy, canonicity or Merkle hypothesis appears.  The anchor
+      row needs no side condition — it is itself an input
+      ([in_anchor_public]); the five remaining ⊥-free output rows are
+      exact from acceptance alone.  The two short-lookup premises are the same
+      residual model artifacts as above. *)
+  Definition deterministic_adversarial_claim : Prop :=
+    forall (Γ1 Γ2 : Assignment.t columns RegionId.t),
+      Holds Γ1 ->
+      Holds Γ2 ->
+      NoteCommitNewWords.note_commit_new_short_lookup_ok Γ1 ->
+      NoteCommitNewWords.note_commit_new_short_lookup_ok Γ2 ->
+      read_action_inputs Γ1 = read_action_inputs Γ2 ->
+      cmx_bot_of_inputs orchard_circuit_params (read_action_inputs Γ1) <>
+        None ->
+      forall row : Z,
+        row = Garden.Orchard.circuit.ANCHOR \/
+        row = Garden.Orchard.circuit.CV_NET_X \/
+        row = Garden.Orchard.circuit.CV_NET_Y \/
+        row = Garden.Orchard.circuit.NF_OLD \/
+        row = Garden.Orchard.circuit.RK_X \/
+        row = Garden.Orchard.circuit.RK_Y \/
+        row = Garden.Orchard.circuit.CMX ->
+        read_public_instance Γ1 row = read_public_instance Γ2 row.
+
+  (** ** The discrete-logarithm reading of the ⊥ escapes
+
+      §5.4.1.9's security requirement backs the ⊥ and collision cases
+      cryptographically: Theorem 5.4.3 (a fixed-length collision yields a
+      nontrivial discrete logarithm relation) and Theorem 5.4.4 (an
+      exceptional case — a ⊥ output — yields one).  Both enter only as
+      named hypotheses in the style of the balance proof's
+      [OrchardBundleSpec.dlog_relation] reduction: an explicit relation,
+      never an injectivity or independence axiom.  Nothing here is proved
+      or assumed by the adversarial statement itself. *)
+
+  (** A linear combination of the Sinsemilla domain point and table
+      generators: [c0]·[Q] plus [Σ c·S(j)] over the listed [(j, c)]
+      pairs, in the Pallas group. *)
+  Definition sinsemilla_generator_combination
+      (Q : Point.t) (c0 : Z) (cs : list (Z * Z)) : Pallas.point :=
+    Stdlib.Lists.List.fold_left
+      (fun acc jc =>
+        Pallas.add acc
+          (Pallas.mul (snd jc)
+            (PallasModel.unrepr (SinsemillaSpec.generator (fst jc)))))
+      cs
+      (Pallas.mul c0 (PallasModel.unrepr Q)).
+
+  (** A nontrivial discrete-logarithm relation among [Q] and the [S(j)]:
+      the combination vanishes while not every coefficient vanishes
+      mod the group order. *)
+  Definition sinsemilla_dlog_relation
+      (Q : Point.t) (c0 : Z) (cs : list (Z * Z)) : Prop :=
+    sinsemilla_generator_combination Q c0 cs = Pallas.identity /\
+    ~ (c0 mod Pallas.pallas_q = 0 /\
+       List.Forall (fun jc => snd jc mod Pallas.pallas_q = 0) cs).
+
+  (** Theorem 5.4.3 as a named reduction hypothesis: a fixed-length
+      collision of the ⊥-carrying hash-to-point yields a relation. *)
+  Definition SinsemillaCollisionReduction : Prop :=
+    forall (Q : Point.t) (ws ws' : list Z),
+      List.length ws = List.length ws' ->
+      ws <> ws' ->
+      sinsemilla_hash_to_point_bot Q ws =
+        sinsemilla_hash_to_point_bot Q ws' ->
+      sinsemilla_hash_to_point_bot Q ws <> None ->
+      exists (c0 : Z) (cs : list (Z * Z)),
+        sinsemilla_dlog_relation Q c0 cs.
+
+  (** Theorem 5.4.4 as a named reduction hypothesis: a ⊥ output of the
+      hash-to-point yields a relation (the exceptional operand pair is a
+      linear identity among the accumulator's combination and one
+      generator). *)
+  Definition SinsemillaExceptionalDlogReduction : Prop :=
+    forall (Q : Point.t) (ws : list Z),
+      sinsemilla_hash_to_point_bot Q ws = None ->
+      exists (c0 : Z) (cs : list (Z * Z)),
+        sinsemilla_dlog_relation Q c0 cs.
+
+  (** Statement only — no proof is attempted in this development.  Under
+      the Theorem 5.4.4 reduction, [anchor_obligation]'s §4.9 escape
+      converts into an explicit discrete-logarithm disjunct: an accepted
+      assignment either is a dummy spend, or exhibits a relation among the
+      Merkle domain point and the Sinsemilla generators, or carries a
+      valid witnessed path to the anchor.  This is the §4.9 note's own
+      argument — "a ⊥ output from SinsemillaHash yields a nontrivial
+      discrete logarithm relation.  Since we assume finding such a
+      relation to be infeasible, we can argue that it is safe to allow an
+      adversary to create a proof that passes the Merkle validity check in
+      such a case." *)
+  Definition anchor_exceptional_or_dlog_claim : Prop :=
+    SinsemillaExceptionalDlogReduction ->
+    forall (Γ : Assignment.t columns RegionId.t),
+      Holds Γ ->
+      merkle_b_range_ok Γ ->
+      OrchardSpec.in_v_old (read_action_inputs Γ) = 0 \/
+      (exists (c0 : Z) (cs : list (Z * Z)),
+         sinsemilla_dlog_relation OrchardActionMerkle.merkle_Q c0 cs) \/
+      anchor_path_tracks Γ.
+
+End OrchardAdversarialApi.

--- a/Garden/Orchard/circuit_proof/cv_net_value.v
+++ b/Garden/Orchard/circuit_proof/cv_net_value.v
@@ -31,8 +31,7 @@
     theorems carries a Merkle or nondegeneracy hypothesis — acceptance and
     the two short-lookup families are the whole premise set, and both
     families are discharged from acceptance of the pinned circuit
-    ([circuit_proof/lookup_closure.v],
-    [circuit_proof/lookup_closure_old_note.v]). *)
+    ([circuit_adversarial.v]). *)
 
 Require Import Garden.Halo2.main.
 Require Import Garden.Halo2.proof.

--- a/Garden/Orchard/circuit_proof/cv_net_value.v
+++ b/Garden/Orchard/circuit_proof/cv_net_value.v
@@ -6,10 +6,10 @@
     [v_old - v_new].
 
     - [CvNetValue.cv_net_value_balance_sound]: the [CV_NET] projection of
-      [OrchardAction.satisfies_specification] conjoined with the extracted
-      balance gate ([OrchardValidActionInputs.value_balance_gate]) — a
-      composed no-inflation statement inside the relational model:
-      the public [CV_NET] is the deterministic value commitment to the same
+      functional correctness conjoined with the extracted balance gate
+      ([OrchardValidActionInputs.value_balance_gate]) — a composed
+      no-inflation statement inside the relational model: the public
+      [CV_NET] is the deterministic value commitment to the same
       magnitude/sign pair the Orchard gate equates with [v_old - v_new].
     - [CvNetValue.cv_net_commits_net_value]: the §4.18.4 'Value commitment
       integrity' shape — [cv_net = ValueCommit^Orchard_rcv(v)] for the
@@ -22,11 +22,17 @@
       [cv_net = ValueCommit^Orchard_rcv(v_old - v_new)] over ℤ, with the
       64-bit ranges of the [v_old]/[v_new] cells circuit-derived
       ([TypedInputsValue64], via the note-commit value-slot decompositions)
-      under the two short-lookup honesty predicates: the new-note one is
-      the second conjunct of the [note_commit_witness_ok] hypothesis the
-      theorem already carries, and the old-note one
-      ([OldNoteWords.old_note_short_lookup_ok]) is the second conjunct of
-      [OrchardValidActionInputs.old_note_witness_ok]. *)
+      under the two short-lookup honesty predicates
+      ([NoteCommitNewWords.note_commit_new_short_lookup_ok] and
+      [OldNoteWords.old_note_short_lookup_ok]).
+
+    The [CV_NET] row is one of the five ⊥-free public outputs: it uses
+    complete addition and total group multiples only, so none of the three
+    theorems carries a Merkle or nondegeneracy hypothesis — acceptance and
+    the two short-lookup families are the whole premise set, and both
+    families are discharged from acceptance of the pinned circuit
+    ([circuit_proof/lookup_closure.v],
+    [circuit_proof/lookup_closure_old_note.v]). *)
 
 Require Import Garden.Halo2.main.
 Require Import Garden.Halo2.proof.
@@ -37,8 +43,11 @@ Require Import Garden.Orchard.protocol_spec.
 Require Import Garden.Orchard.circuit_proof.inputs.
 Require Import Garden.Orchard.circuit_proof.merkle.
 Require Import Garden.Orchard.circuit_proof.note_commit.cmx.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
 Require Import Garden.Orchard.circuit_proof.old_note.words.
 Require Import Garden.Orchard.circuit_proof.typed_inputs.value64.
+Require Import Garden.Orchard.circuit_proof.protocol_equiv.
+Require Import Garden.Orchard.circuit_proof.us_free.nullifier_k.
 Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
 Require Import Garden.Orchard.circuit_proof.protocol_mul.signed.
 Require Import Garden.Orchard.circuit_proof.main.
@@ -79,18 +88,64 @@ Module CvNetValue.
       (OrchardSpec.in_rcv inp).
   Proof. reflexivity. Qed.
 
+  (** ** The [CV_NET] output from acceptance alone
+
+      [OrchardAction.satisfies_specification] carries the whole output
+      record and therefore the Merkle and new-note witness-honesty
+      conditions of the anchor and [CMX] rows.  The value-commitment row
+      needs neither: [OrchardAction.cv_net_{x,y}_correct] are
+      [Holds]-only, and the protocol reading of the circuit-structured spec
+      is the same composition [satisfies_specification] performs
+      internally — the square-root witness elimination followed by the
+      protocol equivalence, whose typing premise is itself circuit-derived. *)
+
+  Lemma point_eta (P : Point.t) :
+    {| Point.x := Point.x P; Point.y := Point.y P |} = P.
+  Proof. destruct P; reflexivity. Qed.
+
+  Lemma out_cv_net_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.out_cv_net (read_action_outputs Γ) =
+      {| Point.x := read_public_instance Γ Garden.Orchard.circuit.CV_NET_X;
+         Point.y := read_public_instance Γ Garden.Orchard.circuit.CV_NET_Y |}.
+  Proof. reflexivity. Qed.
+
+  Lemma action_spec_protocol
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    OrchardAction.action_spec_of Γ =
+    OrchardProtocolSpec.orchard_action_spec orchard_circuit_params
+      (read_action_inputs Γ).
+  Proof.
+    exact (eq_trans
+      (OrchardActionUsFreeNullifierK.action_spec_us_free Γ Hcircuit)
+      (OrchardProtocolEquiv.output_protocol_eq (read_action_inputs Γ)
+        (OrchardValidActionInputs.protocol_typed_inputs_of_holds
+          Γ Hcircuit))).
+  Qed.
+
+  Lemma cv_net_output_of_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    OrchardSpec.out_cv_net (read_action_outputs Γ) =
+      OrchardSpec.out_cv_net
+        (OrchardProtocolSpec.orchard_action_spec orchard_circuit_params
+          (read_action_inputs Γ)).
+  Proof.
+    rewrite out_cv_net_read.
+    rewrite (OrchardAction.cv_net_x_correct Γ Hcircuit).
+    rewrite (OrchardAction.cv_net_y_correct Γ Hcircuit).
+    rewrite (action_spec_protocol Γ Hcircuit).
+    apply point_eta.
+  Qed.
+
   (** The composition of [CV_NET] functional correctness with the balance
       gate: the public [CV_NET] output is the protocol value commitment of
       the witnessed magnitude/sign pair, and that same pair is equated with
       [v_old - v_new] by the [QOrchard] gate (field arithmetic).  Pure
       composition: the [out_cv_net] projection of
-      [OrchardAction.satisfies_specification] and
+      [cv_net_output_of_holds] and
       [OrchardValidActionInputs.value_balance_gate]. *)
   Theorem cv_net_value_balance_sound
       (Γ : Assignment.t columns RegionId.t)
-      (Hcircuit : Holds Γ)
-      (Hmerkle_ok : OrchardActionMerkle.merkle_witness_ok Γ)
-      (Hnote_ok : NoteCommitNewCmx.note_commit_witness_ok Γ) :
+      (Hcircuit : Holds Γ) :
     OrchardSpec.out_cv_net (read_action_outputs Γ) =
       OrchardSpec.out_cv_net
         (OrchardProtocolSpec.orchard_action_spec orchard_circuit_params
@@ -101,9 +156,7 @@ Module CvNetValue.
       OrchardSpec.in_sign (read_action_inputs Γ).
   Proof.
     split.
-    - rewrite (OrchardAction.satisfies_specification
-        Γ Hcircuit Hmerkle_ok Hnote_ok).
-      reflexivity.
+    - exact (cv_net_output_of_holds Γ Hcircuit).
     - exact (OrchardValidActionInputs.value_balance_gate Γ Hcircuit).
   Qed.
 
@@ -119,9 +172,7 @@ Module CvNetValue.
       through [SignedValueAlgebra]'s [signed_net_value] evaluations. *)
   Theorem cv_net_commits_net_value
       (Γ : Assignment.t columns RegionId.t)
-      (Hcircuit : Holds Γ)
-      (Hmerkle_ok : OrchardActionMerkle.merkle_witness_ok Γ)
-      (Hnote_ok : NoteCommitNewCmx.note_commit_witness_ok Γ) :
+      (Hcircuit : Holds Γ) :
     let inp := read_action_inputs Γ in
     let v :=
       OrchardProtocolSpec.signed_net_value
@@ -142,8 +193,7 @@ Module CvNetValue.
     unfold BinOp.sub, BinOp.mul in Hgate.
     refine (conj _ (conj _ _)).
     - (* cv_net = value_commit (signed_net_value magnitude sign) rcv *)
-      rewrite (OrchardAction.satisfies_specification
-        Γ Hcircuit Hmerkle_ok Hnote_ok).
+      rewrite (cv_net_output_of_holds Γ Hcircuit).
       exact
         (out_cv_net_spec_proj orchard_circuit_params (read_action_inputs Γ)).
     - (* signed_net_value magnitude sign ≡ v_old - v_new (mod pallas_p) *)
@@ -184,17 +234,15 @@ Module CvNetValue.
       witness cell, so the bound follows from [Holds Γ] plus the
       short-lookup honesty predicate of the corresponding note-commit lane
       (the selector-plane idealization of the relational model; see the
-      [old_note/words.v] file header).  The new-note predicate is the
-      second conjunct of [Hnote_ok]
-      ([NoteCommitNewCmx.note_commit_witness_ok]); the old-note one enters
-      as the explicit [Hold_short] hypothesis — it is the second conjunct
-      of [OrchardValidActionInputs.old_note_witness_ok], the predicate the
-      old-note integrity track already carries. *)
+      [old_note/words.v] file header).  Both enter as explicit hypotheses,
+      and both are discharged from acceptance of the pinned circuit by the
+      lookup-closure files ([circuit_proof/lookup_closure.v],
+      [circuit_proof/lookup_closure_old_note.v]).  No nondegeneracy or
+      Merkle condition is needed: the [CV_NET] row is ⊥-free. *)
   Theorem cv_net_commits_net_value_Z
       (Γ : Assignment.t columns RegionId.t)
       (Hcircuit : Holds Γ)
-      (Hmerkle_ok : OrchardActionMerkle.merkle_witness_ok Γ)
-      (Hnote_ok : NoteCommitNewCmx.note_commit_witness_ok Γ)
+      (Hnew_short : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ)
       (Hold_short : OldNoteWords.old_note_short_lookup_ok Γ) :
     OrchardSpec.out_cv_net (read_action_outputs Γ) =
       OrchardProtocolSpec.value_commit
@@ -205,10 +253,9 @@ Module CvNetValue.
     pose proof
       (TypedInputsValue64.in_v_old_64 Γ Hcircuit Hold_short) as Hv_old_64.
     pose proof
-      (TypedInputsValue64.in_v_new_64 Γ Hcircuit (proj2 Hnote_ok))
+      (TypedInputsValue64.in_v_new_64 Γ Hcircuit Hnew_short)
       as Hv_new_64.
-    pose proof
-      (cv_net_commits_net_value Γ Hcircuit Hmerkle_ok Hnote_ok) as H.
+    pose proof (cv_net_commits_net_value Γ Hcircuit) as H.
     cbv zeta in H.
     destruct H as (Hcv & Hmod & Habs).
     assert (Hp :

--- a/Garden/Orchard/circuit_proof/lookup_closure.v
+++ b/Garden/Orchard/circuit_proof/lookup_closure.v
@@ -1,0 +1,810 @@
+(** * Deriving the short-lookup range facts from operational acceptance
+
+    The relational model leaves the [QRunning] selector free at the rows
+    where a short range check fires, so the ten-bit lookup bound on the
+    checked cell is not derivable from [Holds] alone: a dishonest
+    assignment can set [QRunning] nonzero there and route the lookup
+    through the running-sum branch (see the header of
+    [circuit_proof/note_commit/words.v]).  Operational acceptance closes
+    that gap.  The realized assignment reads its selector plane from the
+    replayed grid at absolute rows, and the pinned Orchard event stream
+    enables [QRunning] at none of the short-range rows, so the selector is
+    the initial grid's zero there.
+
+    The file provides:
+
+    - [replay_selector_unset]: a selector index/row that no event enables
+      keeps the initial grid's value along any successful replay;
+    - [ten_bit_bound_at]: the short branch of the shared range-check
+      lookup argument ([RangeTable.short_word_sound]) at a row where
+      [QLookup] is on and [QRunning] is off;
+    - [bitshift_gate_at]: the companion [Short lookup bitshift] gate;
+    - [short_range_bound]: the width-tightening extraction lemma — one
+      lemma parameterized on the region, the bit width and the pinned
+      inverse constant, covering every short-range site of the circuit;
+    - the row-inventory certificates over the pinned event stream and the
+      reified synthesis facts, factored through one generic per-site
+      lemma;
+    - [note_commit_new_short_lookup_ok_operational]: the whole eleven-cell
+      new-note family, from replay success and ideal operational
+      acceptance of the serialized Orchard circuit. *)
+
+Require Import Stdlib.Bool.Bool.
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.micromega.Lia.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.serialize.
+Require Import Garden.Halo2.realize.main.
+Require Import Garden.Halo2.realize.sound.
+Require Garden.Halo2.halo2_gadgets.utilities.lookup_range_check.
+Require Import Garden.Halo2.halo2_gadgets.utilities.lookup_range_check_proof.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.chip_proof.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.decidable_eq.
+Require Import Garden.Orchard.circuit_synthesis_layout.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.circuit_proof.facts.
+Require Import Garden.Orchard.circuit_proof.merkle.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+Require Import Garden.Orchard.circuit_operational.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardShortLookupClosure.
+  Import OrchardDecidableEq.
+  Import OrchardActionMerkle.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** ** A selector no event enables keeps the initial grid's value
+
+      The positive direction ([Halo2/realize/facts.v]
+      [replay_selector_pinned]) reads an enabled point out of the replay
+      log.  This is the negative direction: [apply_event] touches
+      [RawGrid.sel] only in the [EnableSelector] branch, and
+      [RawGrid.set_selector] changes the plane only at the written point,
+      so a point that no event writes is untouched by the whole replay. *)
+
+  Definition selector_enabled_at (column row : Z) (event : Raw.Event.t)
+      : bool :=
+    match event with
+    | Raw.Event.EnableSelector c r _ => andb (c =? column) (r =? row)
+    | _ => false
+    end.
+
+  Lemma apply_events_log_selector_unset
+      (events : list Raw.Event.t) (column row : Z)
+      (Hnone :
+        List.forallb (fun e => negb (selector_enabled_at column row e))
+          events = true)
+      (state state' : ReplayState.t)
+      (Happly : apply_events_log events state = Some state') :
+    state'.(ReplayState.grid).(RawGrid.sel) column row =
+      state.(ReplayState.grid).(RawGrid.sel) column row.
+  Proof.
+    revert state Happly.
+    induction events as [| event events IH];
+      cbn in Hnone |- *; intros state Happly.
+    - injection Happly as <-.
+      reflexivity.
+    - apply andb_true_iff in Hnone.
+      destruct Hnone as [Hhead Htail].
+      destruct (apply_event state event) as [state1 |] eqn:Hevent;
+        [| discriminate Happly].
+      rewrite (IH Htail state1 Happly).
+      revert Hevent.
+      destruct event as
+        [name | name | name | name | c r annotation
+        | c r annotation value | left_cell right_cell
+        | c from_row to_row value];
+        cbn;
+        try (intros Hevent; injection Hevent as <-; reflexivity).
+      + destruct (List.existsb (write_conflicts_write c r 1)
+            state.(ReplayState.log).(Log.selectors));
+          intros Hevent; [discriminate Hevent |].
+        injection Hevent as <-.
+        cbn.
+        cbn [selector_enabled_at] in Hhead.
+        apply negb_true_iff in Hhead.
+        destruct (andb (column =? c) (row =? r)) eqn:Hpoint; [| reflexivity].
+        apply andb_true_iff in Hpoint.
+        destruct Hpoint as [Hc Hr].
+        apply Z.eqb_eq in Hc, Hr.
+        subst.
+        rewrite !Z.eqb_refl in Hhead.
+        discriminate Hhead.
+      + destruct (orb
+            (List.existsb (write_conflicts_write c r value)
+              state.(ReplayState.log).(Log.fixeds))
+            (List.existsb (write_conflicts_fill c r value)
+              state.(ReplayState.log).(Log.fills)));
+          intros Hevent; [discriminate Hevent |].
+        injection Hevent as <-.
+        reflexivity.
+      + destruct (orb
+            (List.existsb (fill_conflicts_write c from_row to_row value)
+              state.(ReplayState.log).(Log.fixeds))
+            (List.existsb (fill_conflicts_fill c from_row to_row value)
+              state.(ReplayState.log).(Log.fills)));
+          intros Hevent; [discriminate Hevent |].
+        injection Hevent as <-.
+        reflexivity.
+  Qed.
+
+  Lemma replay_selector_unset
+      (events : list Raw.Event.t) (initial final : RawGrid.t)
+      (column row : Z)
+      (Hreplay : apply_events events initial = Some final)
+      (Hnone :
+        List.forallb (fun e => negb (selector_enabled_at column row e))
+          events = true) :
+    final.(RawGrid.sel) column row = initial.(RawGrid.sel) column row.
+  Proof.
+    unfold apply_events in Hreplay.
+    destruct (apply_events_log events (ReplayState.init initial))
+      as [state |] eqn:Hlog; [| discriminate Hreplay].
+    injection Hreplay as <-.
+    exact (apply_events_log_selector_unset events column row Hnone
+      (ReplayState.init initial) state Hlog).
+  Qed.
+
+  (** The witness supplies no selector plane, so the initial grid holds
+      [0] at every selector point. *)
+  Lemma realized_selector_unset
+      (events : list Raw.Event.t) (advice instance_ : Z -> Z -> Z)
+      (grid : RawGrid.t) (column row : Z)
+      (Hreplay :
+        apply_events events (initial_grid advice instance_) = Some grid)
+      (Hnone :
+        List.forallb (fun e => negb (selector_enabled_at column row e))
+          events = true) :
+    grid.(RawGrid.sel) column row = 0.
+  Proof.
+    exact (replay_selector_unset events (initial_grid advice instance_) grid
+      column row Hreplay Hnone).
+  Qed.
+
+  (** ** Reflection from a membership checker to [List.In]
+
+      Only the two fact shapes this file reads are compared; every other
+      pair is rejected, which keeps [fact_beq_eq] a three-case proof. *)
+
+  Definition fact_beq (f g : Fact.t columns RegionId.t) : bool :=
+    match f, g with
+    | Fact.SelectorOn s r o, Fact.SelectorOn s' r' o' =>
+        andb (andb (selector_eqb s s') (region_id_eqb r r')) (o =? o')
+    | Fact.CellIsConstant c v, Fact.CellIsConstant c' v' =>
+        andb (cell_eqb c c') (v =? v')
+    | _, _ => false
+    end.
+
+  Lemma fact_beq_eq (f g : Fact.t columns RegionId.t) :
+    fact_beq f g = true -> f = g.
+  Proof.
+    destruct f, g; cbn [fact_beq]; intros Hb; try discriminate Hb.
+    - apply andb_true_iff in Hb; destruct Hb as [Hb Ho].
+      apply andb_true_iff in Hb; destruct Hb as [Hs Hr].
+      apply selector_eqb_eq in Hs.
+      apply region_id_eqb_eq in Hr.
+      apply Z.eqb_eq in Ho.
+      subst.
+      reflexivity.
+    - apply andb_true_iff in Hb; destruct Hb as [Hc Hv].
+      apply cell_eqb_eq in Hc.
+      apply Z.eqb_eq in Hv.
+      subst.
+      reflexivity.
+  Qed.
+
+  Lemma fact_In_of_beq (f : Fact.t columns RegionId.t)
+      (l : list (Fact.t columns RegionId.t)) :
+    List.existsb (fact_beq f) l = true -> List.In f l.
+  Proof.
+    intros Hex.
+    apply List.existsb_exists in Hex.
+    destruct Hex as [g Hg].
+    destruct Hg as [Hin Hb].
+    rewrite (fact_beq_eq _ _ Hb).
+    exact Hin.
+  Qed.
+
+  (** ** The shared range-check lookup argument
+
+      The circuit configures exactly one range check
+      ([lookup_range_check.configure 10 QLookup QRunning QBitshift A9
+      TableIdx] at [circuit.configure]); every short-range site of every
+      family uses it.  Its [TableIdx] column is the ten-bit index column
+      of the shared generator-table load. *)
+
+  Definition range_check_argument : LookupArgument.t columns :=
+    RangeTable.argument 10 Selector.QLookup Selector.QRunning
+      Advice.A9 Lookup.TableIdx.
+
+  Lemma range_check_lookup_holds
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ)
+      (region : RegionId.t) (row : Z) :
+    eval_lookup_argument Γ (region, row)
+      Garden.Halo2.halo2_gadgets.sinsemilla.chip_proof.GeneratorTable
+        .table_rows
+      range_check_argument.
+  Proof.
+    rewrite <- OrchardActionMerkle.orchard_table_rows_eq.
+    apply (OrchardActionMerkle.satisfies_lookups_at Γ
+      (layouter_table_rows Garden.Orchard.circuit.synthesize)
+      orchard_constraint_system
+      range_check_argument
+      region row).
+    - unfold orchard_constraint_system, range_check_argument.
+      cbn.
+      repeat (first [left; reflexivity | right]).
+    - exact (holds_lookups Γ Hcircuit).
+  Qed.
+
+  (** The short branch: at a row where [QLookup] is on and [QRunning] is
+      off, the lookup input collapses to the [A9] cell itself, so table
+      membership is the ten-bit bound. *)
+  Lemma ten_bit_bound_at
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ)
+      (region : RegionId.t) (row : Z)
+      (Hlk : Γ.(Assignment.selector) Selector.QLookup region row = 1)
+      (Hrun : Γ.(Assignment.selector) Selector.QRunning region row = 0) :
+    0 <=
+      UnOp.from
+        (eval_cell Γ
+          (Garden.Halo2.Synthesis.Cell.advice region Advice.A9 row)) <
+      2 ^ 10.
+  Proof.
+    rewrite <- (eval_advice_cur_cell Γ region Advice.A9 row).
+    pose proof (range_check_lookup_holds Γ Hcircuit region row) as Hlookup.
+    rewrite Garden.Halo2.halo2_gadgets.sinsemilla.chip_proof.GeneratorTable
+      .table_rows_eq in Hlookup.
+    change (2 ^ Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_k)
+      with (2 ^ 10) in Hlookup.
+    apply (RangeTable.short_word_sound Γ 10 Selector.QLookup Selector.QRunning
+      Advice.A9 Lookup.TableIdx (2 ^ 10) region row).
+    - intros i Hi.
+      exact (Garden.Halo2.halo2_gadgets.sinsemilla.chip_proof.GeneratorTable
+        .loaded Γ (OrchardActionMerkle.generator_table_facts Γ Hcircuit)
+        Lookup.TableIdx i Hi).
+    - exact Hlk.
+    - exact Hrun.
+    - exact Hlookup.
+  Qed.
+
+  (** ** The companion bitshift gate *)
+
+  Lemma bitshift_gate_In :
+    List.In
+      (Garden.Halo2.halo2_gadgets.utilities.lookup_range_check
+        .short_lookup_bitshift_gate (columns := columns)
+        10 Selector.QBitshift Advice.A9)
+      (𝓒.run_unit Garden.Orchard.circuit.configure
+        ConstraintSystem.empty).(ConstraintSystem.gates).
+  Proof.
+    cbn.
+    repeat (first [left; reflexivity | right]).
+  Qed.
+
+  Lemma bitshift_gate_at
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ)
+      (region : RegionId.t)
+      (Hbs : Γ.(Assignment.selector) Selector.QBitshift region 1 = 1) :
+    BinOp.mul
+      (BinOp.mul
+        (UnOp.from (Γ.(Assignment.advice) Advice.A9 region 0))
+        (UnOp.from (2 ^ 10)))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9 region 2)) =
+    UnOp.from (Γ.(Assignment.advice) Advice.A9 region 1).
+  Proof.
+    pose proof (satisfies_gates_at Γ
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+      (Garden.Halo2.halo2_gadgets.utilities.lookup_range_check
+        .short_lookup_bitshift_gate (columns := columns)
+        10 Selector.QBitshift Advice.A9)
+      region 1 bitshift_gate_In (holds_gates Γ Hcircuit)) as Hgate.
+    with_strategy opaque [BinOp.add BinOp.sub BinOp.mul UnOp.from]
+      cbn in Hgate.
+    rewrite Hbs in Hgate.
+    change (2 ^ 10) with 1024.
+    apply Hgate.
+    rewrite FieldRewrite.from_one.
+    clear.
+    unfold Primes.pallas_p.
+    lia.
+  Qed.
+
+  (** ** The width-tightening arithmetic
+
+      With the pinned inverse [inv] satisfying [2^10 * inv = 2^(10 - bits)]
+      in the field, the bitshift row reads, over the integers,
+      [z_1 = z_0 * 2^(10 - bits)]: the product is below [2^20 < p], so the
+      reduction is the identity and the ten-bit bound on [z_1] tightens the
+      ten-bit bound on [z_0] to [bits] bits. *)
+
+  Lemma pallas_p_big : 2 ^ 20 < Primes.pallas_p.
+  Proof.
+    apply Z.ltb_lt.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma short_word_tighten (p a b inv bits : Z)
+      (Hp : 2 ^ 20 < p)
+      (Hbits : 0 <= bits <= 10)
+      (Ha : 0 <= a < 2 ^ 10)
+      (Hb : 0 <= b < 2 ^ 10)
+      (Hinv : (2 ^ 10 * inv) mod p = 2 ^ (10 - bits))
+      (Hgate : (a * (2 ^ 10 mod p) mod p * (inv mod p)) mod p = b) :
+    a < 2 ^ bits.
+  Proof.
+    assert (Hpow_lo : 0 < 2 ^ (10 - bits))
+      by (apply Z.pow_pos_nonneg; clear -Hbits; lia).
+    assert (Hpow_hi : 2 ^ (10 - bits) <= 2 ^ 10)
+      by (apply Z.pow_le_mono_r; clear -Hbits; lia).
+    assert (Hsplit : 2 ^ bits * 2 ^ (10 - bits) = 2 ^ 10).
+    { rewrite <- Z.pow_add_r by (clear -Hbits; lia).
+      f_equal.
+      clear -Hbits; lia. }
+    assert (Hbound : 0 <= a * 2 ^ (10 - bits) < p).
+    { assert (Hnn : 0 <= a * 2 ^ (10 - bits))
+        by (apply Z.mul_nonneg_nonneg; clear -Ha Hpow_lo; lia).
+      assert (Hle : a * 2 ^ (10 - bits) <= (2 ^ 10 - 1) * 2 ^ 10).
+      { apply Z.mul_le_mono_nonneg;
+          clear -Ha Hpow_lo Hpow_hi; lia. }
+      change ((2 ^ 10 - 1) * 2 ^ 10) with 1047552 in Hle.
+      change (2 ^ 20) with 1048576 in Hp.
+      clear -Hnn Hle Hp; lia. }
+    rewrite Zmult_mod_idemp_r in Hgate.
+    rewrite Zmult_mod_idemp_l in Hgate.
+    replace (a * (2 ^ 10 mod p) * inv) with (a * inv * (2 ^ 10 mod p))
+      in Hgate by ring.
+    rewrite Zmult_mod_idemp_r in Hgate.
+    replace (a * inv * 2 ^ 10) with (a * (2 ^ 10 * inv)) in Hgate by ring.
+    assert (Hstep :
+        (a * (2 ^ 10 * inv)) mod p = (a * ((2 ^ 10 * inv) mod p)) mod p)
+      by (rewrite Zmult_mod_idemp_r; reflexivity).
+    rewrite Hstep, Hinv, (Z.mod_small _ _ Hbound) in Hgate.
+    rewrite <- Hgate in Hb.
+    rewrite <- Hsplit in Hb.
+    apply (proj2 (Z.mul_lt_mono_pos_r (2 ^ (10 - bits)) a (2 ^ bits) Hpow_lo)).
+    clear -Hb; lia.
+  Qed.
+
+  (** ** The generic extraction lemma
+
+      One lemma for every short-range site of the circuit, parameterized on
+      the region, the bit width and the pinned inverse constant.  All the
+      premises except the two [QRunning] readings are consequences of
+      [Holds Γ] for an arbitrary [Γ]; those two are where operational
+      acceptance enters. *)
+
+  Lemma advice_cell_read
+      (Γ : Assignment.t columns RegionId.t)
+      (region : RegionId.t) (column : Advice.t) (row : Z) :
+    eval_cell Γ (Garden.Halo2.Synthesis.Cell.advice region column row) =
+      Γ.(Assignment.advice) column region row.
+  Proof.
+    reflexivity.
+  Qed.
+
+  Lemma short_range_bound
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ)
+      (region : RegionId.t) (bits inv : Z)
+      (Hbits : 0 <= bits <= 10)
+      (Hinv : UnOp.from (2 ^ 10 * inv) = 2 ^ (10 - bits))
+      (Hconst :
+        List.In
+          (Fact.CellIsConstant
+            (Garden.Halo2.Synthesis.Cell.advice region Advice.A9 2) inv)
+          (layouter_facts Garden.Orchard.circuit.synthesize))
+      (Hlk0 :
+        List.In (Fact.SelectorOn Selector.QLookup region 0)
+          (layouter_facts Garden.Orchard.circuit.synthesize))
+      (Hlk1 :
+        List.In (Fact.SelectorOn Selector.QLookup region 1)
+          (layouter_facts Garden.Orchard.circuit.synthesize))
+      (Hbs1 :
+        List.In (Fact.SelectorOn Selector.QBitshift region 1)
+          (layouter_facts Garden.Orchard.circuit.synthesize))
+      (Hrun0 : Γ.(Assignment.selector) Selector.QRunning region 0 = 0)
+      (Hrun1 : Γ.(Assignment.selector) Selector.QRunning region 1 = 0) :
+    0 <=
+      UnOp.from
+        (eval_cell Γ
+          (Garden.Halo2.Synthesis.Cell.advice region Advice.A9 0)) <
+      2 ^ bits.
+  Proof.
+    pose proof (holds_facts Γ Hcircuit) as Hfacts.
+    pose proof (interpret_facts_In Γ _ _ Hfacts Hlk0) as Hlk0'.
+    pose proof (interpret_facts_In Γ _ _ Hfacts Hlk1) as Hlk1'.
+    pose proof (interpret_facts_In Γ _ _ Hfacts Hbs1) as Hbs1'.
+    pose proof (interpret_facts_In Γ _ _ Hfacts Hconst) as Hconst'.
+    cbn [interpret_fact] in Hlk0', Hlk1', Hbs1', Hconst'.
+    rewrite advice_cell_read in Hconst'.
+    pose proof (ten_bit_bound_at Γ Hcircuit region 0 Hlk0' Hrun0) as Ha.
+    pose proof (ten_bit_bound_at Γ Hcircuit region 1 Hlk1' Hrun1) as Hb.
+    pose proof (bitshift_gate_at Γ Hcircuit region Hbs1') as Hgate.
+    rewrite advice_cell_read in Ha, Hb.
+    rewrite Hconst' in Hgate.
+    split; [apply Z.mod_pos_bound, Primes.pallas_p_pos |].
+    unfold BinOp.mul, UnOp.from in Hgate, Hinv.
+    apply (short_word_tighten Primes.pallas_p
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9 region 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9 region 1))
+      inv bits pallas_p_big Hbits Ha Hb Hinv Hgate).
+  Qed.
+
+  (** ** The row inventory
+
+      Each short-range site is a three-row region emitting [QLookup] at
+      offsets [0] and [1], [QBitshift] at offset [1], and a
+      [ConstrainConstant] of the [A9] cell at offset [2] to the inverse of
+      [2^bits].  [QRunning] is enabled nowhere inside it.  The record
+      pins, per site, the region, the width, the inverse constant and the
+      absolute placement row; the certificates below check the four facts,
+      the placement, the inverse identity and the [QRunning] absence
+      against the pinned data. *)
+
+  Record ShortSite : Set := {
+    ss_region : RegionId.t;
+    ss_bits : Z;
+    ss_inv : Z;
+    ss_start : Z;
+  }.
+
+  (** The reified synthesis facts and the serialized event stream, bound
+      as globals so each certificate's [vm_compute] forces them once per
+      compilation unit. *)
+  Definition orchard_facts : list (Fact.t columns RegionId.t) :=
+    layouter_facts Garden.Orchard.circuit.synthesize.
+
+  (** The [QRunning] selector's column index in the serialized grid. *)
+  Definition qrunning_index : Z := 3.
+
+  Lemma qrunning_index_eq :
+    Index.indices.(Indices.selector) Selector.QRunning = qrunning_index.
+  Proof.
+    vm_cast_no_check (@eq_refl Z qrunning_index).
+  Qed.
+
+  Definition site_facts_ok (site : ShortSite) : bool :=
+    andb
+      (andb
+        (List.existsb
+          (fact_beq (Fact.SelectorOn Selector.QLookup site.(ss_region) 0))
+          orchard_facts)
+        (List.existsb
+          (fact_beq (Fact.SelectorOn Selector.QLookup site.(ss_region) 1))
+          orchard_facts))
+      (andb
+        (List.existsb
+          (fact_beq (Fact.SelectorOn Selector.QBitshift site.(ss_region) 1))
+          orchard_facts)
+        (List.existsb
+          (fact_beq
+            (Fact.CellIsConstant
+              (Garden.Halo2.Synthesis.Cell.advice site.(ss_region) Advice.A9 2)
+              site.(ss_inv)))
+          orchard_facts)).
+
+  Definition site_start_ok (site : ShortSite) : bool :=
+    region_start_of site.(ss_region) =? site.(ss_start).
+
+  Definition site_inv_ok (site : ShortSite) : bool :=
+    andb
+      (andb (0 <=? site.(ss_bits)) (site.(ss_bits) <=? 10))
+      ((2 ^ 10 * site.(ss_inv)) mod Primes.pallas_p =?
+        2 ^ (10 - site.(ss_bits))).
+
+  Definition site_qrunning_ok (site : ShortSite) : bool :=
+    andb
+      (List.forallb
+        (fun e =>
+          negb (selector_enabled_at qrunning_index site.(ss_start) e))
+        orchard_events)
+      (List.forallb
+        (fun e =>
+          negb (selector_enabled_at qrunning_index (site.(ss_start) + 1) e))
+        orchard_events).
+
+  (** ** The new-note family sites *)
+
+  Definition site_nc_new_b0 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeB0;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 676;
+  |}.
+
+  Definition site_nc_new_b3 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeB3;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 679;
+  |}.
+
+  Definition site_nc_new_d2 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeD2;
+    ss_bits := 8;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_8;
+    ss_start := 703;
+  |}.
+
+  Definition site_nc_new_e0 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeE0;
+    ss_bits := 6;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_6;
+    ss_start := 709;
+  |}.
+
+  Definition site_nc_new_e1 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeE1;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 724;
+  |}.
+
+  Definition site_nc_new_g1 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeG1;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 727;
+  |}.
+
+  Definition site_nc_new_h0 : ShortSite := {|
+    ss_region := NoteCommitNewWords.ncr RegionId.NoteCommit.RangeH0;
+    ss_bits := 5;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_5;
+    ss_start := 748;
+  |}.
+
+  Definition site_nc_new_gd_k0 : ShortSite := {|
+    ss_region :=
+      NoteCommitNewWords.nyr RegionId.NoteCommit.YSubject.GD
+        RegionId.NoteCommit.YCanonicity.RangeK0;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 754;
+  |}.
+
+  Definition site_nc_new_gd_k2 : ShortSite := {|
+    ss_region :=
+      NoteCommitNewWords.nyr RegionId.NoteCommit.YSubject.GD
+        RegionId.NoteCommit.YCanonicity.RangeK2;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 1621;
+  |}.
+
+  Definition site_nc_new_pkd_k0 : ShortSite := {|
+    ss_region :=
+      NoteCommitNewWords.nyr RegionId.NoteCommit.YSubject.PkD
+        RegionId.NoteCommit.YCanonicity.RangeK0;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 1624;
+  |}.
+
+  Definition site_nc_new_pkd_k2 : ShortSite := {|
+    ss_region :=
+      NoteCommitNewWords.nyr RegionId.NoteCommit.YSubject.PkD
+        RegionId.NoteCommit.YCanonicity.RangeK2;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 1630;
+  |}.
+
+  Definition nc_new_sites : list ShortSite := [
+    site_nc_new_b0;
+    site_nc_new_b3;
+    site_nc_new_d2;
+    site_nc_new_e0;
+    site_nc_new_e1;
+    site_nc_new_g1;
+    site_nc_new_h0;
+    site_nc_new_gd_k0;
+    site_nc_new_gd_k2;
+    site_nc_new_pkd_k0;
+    site_nc_new_pkd_k2
+  ].
+
+  (** ** The certificates *)
+
+  Lemma nc_new_facts_cert :
+    List.forallb site_facts_ok nc_new_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma nc_new_start_cert :
+    List.forallb site_start_ok nc_new_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma nc_new_inv_cert :
+    List.forallb site_inv_ok nc_new_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma nc_new_qrunning_cert :
+    List.forallb site_qrunning_ok nc_new_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  (** ** The generic per-site derivation
+
+      Every premise of [short_range_bound] is read off the certificates at
+      a site of the pinned list; the two [QRunning] readings go through
+      [realized_selector_unset] at the site's absolute rows. *)
+
+  Lemma site_short_bound
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hcircuit :
+        Holds (realize Index.indices region_start_of grid))
+      (sites : list ShortSite)
+      (Hfacts_cert : List.forallb site_facts_ok sites = true)
+      (Hstart_cert : List.forallb site_start_ok sites = true)
+      (Hinv_cert : List.forallb site_inv_ok sites = true)
+      (Hrun_cert : List.forallb site_qrunning_ok sites = true)
+      (site : ShortSite) (Hin : List.In site sites) :
+    0 <=
+      UnOp.from
+        (eval_cell (realize Index.indices region_start_of grid)
+          (Garden.Halo2.Synthesis.Cell.advice site.(ss_region) Advice.A9 0)) <
+      2 ^ site.(ss_bits).
+  Proof.
+    pose proof
+      (proj1 (List.forallb_forall site_facts_ok sites) Hfacts_cert site Hin)
+      as Hfacts.
+    pose proof
+      (proj1 (List.forallb_forall site_start_ok sites) Hstart_cert site Hin)
+      as Hstart.
+    pose proof
+      (proj1 (List.forallb_forall site_inv_ok sites) Hinv_cert site Hin)
+      as Hinv.
+    pose proof
+      (proj1 (List.forallb_forall site_qrunning_ok sites) Hrun_cert site Hin)
+      as Hrun.
+    unfold site_facts_ok in Hfacts.
+    apply andb_true_iff in Hfacts.
+    destruct Hfacts as [Hfacts_lk Hfacts_bs].
+    apply andb_true_iff in Hfacts_lk.
+    destruct Hfacts_lk as [Hlk0 Hlk1].
+    apply andb_true_iff in Hfacts_bs.
+    destruct Hfacts_bs as [Hbs1 Hconst].
+    unfold site_start_ok in Hstart.
+    apply Z.eqb_eq in Hstart.
+    unfold site_inv_ok in Hinv.
+    apply andb_true_iff in Hinv.
+    destruct Hinv as [Hbits Hinv_eq].
+    apply andb_true_iff in Hbits.
+    destruct Hbits as [Hbits_lo Hbits_hi].
+    apply Z.leb_le in Hbits_lo, Hbits_hi.
+    apply Z.eqb_eq in Hinv_eq.
+    unfold site_qrunning_ok in Hrun.
+    apply andb_true_iff in Hrun.
+    destruct Hrun as [Hrun0 Hrun1].
+    apply (short_range_bound
+      (realize Index.indices region_start_of grid) Hcircuit
+      site.(ss_region) site.(ss_bits) site.(ss_inv)
+      (conj Hbits_lo Hbits_hi) Hinv_eq
+      (fact_In_of_beq _ _ Hconst)
+      (fact_In_of_beq _ _ Hlk0)
+      (fact_In_of_beq _ _ Hlk1)
+      (fact_In_of_beq _ _ Hbs1)).
+    - cbn [realize Assignment.selector].
+      rewrite qrunning_index_eq, Hstart, Z.add_0_r.
+      exact (realized_selector_unset orchard_events advice instance_ grid
+        qrunning_index site.(ss_start) Hreplay Hrun0).
+    - cbn [realize Assignment.selector].
+      rewrite qrunning_index_eq, Hstart.
+      exact (realized_selector_unset orchard_events advice instance_ grid
+        qrunning_index (site.(ss_start) + 1) Hreplay Hrun1).
+  Qed.
+
+  (** ** The new-note family, from operational acceptance
+
+      [orchard_operational_sound] carries replay success and ideal
+      acceptance to the relational [Holds] of the realized assignment; the
+      site derivations supply the eleven bounds the relational model
+      leaves free. *)
+
+  Lemma nc_new_site_bound
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (site : ShortSite) (Hin : List.In site nc_new_sites) :
+    0 <=
+      UnOp.from
+        (eval_cell (realize Index.indices region_start_of grid)
+          (Garden.Halo2.Synthesis.Cell.advice site.(ss_region) Advice.A9 0)) <
+      2 ^ site.(ss_bits).
+  Proof.
+    exact (site_short_bound advice instance_ grid Hreplay
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      nc_new_sites nc_new_facts_cert nc_new_start_cert nc_new_inv_cert
+      nc_new_qrunning_cert site Hin).
+  Qed.
+
+  Theorem note_commit_new_short_lookup_ok_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    NoteCommitNewWords.note_commit_new_short_lookup_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    unfold NoteCommitNewWords.note_commit_new_short_lookup_ok,
+      NoteCommitNewWords.short_ok, NoteCommitNewWords.val,
+      NoteCommitNewWords.adv.
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_b0
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_b3
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_d2
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_e0
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_e1
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_g1
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_h0
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_gd_k0
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_gd_k2
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+        site_nc_new_pkd_k0
+        ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))) |].
+    exact (nc_new_site_bound advice instance_ grid Hreplay Hmock
+      site_nc_new_pkd_k2
+      ltac:(unfold nc_new_sites; repeat (first [left; reflexivity | right]))).
+  Qed.
+End OrchardShortLookupClosure.

--- a/Garden/Orchard/circuit_proof/lookup_closure_ivk.v
+++ b/Garden/Orchard/circuit_proof/lookup_closure_ivk.v
@@ -1,0 +1,177 @@
+(** * The CommitIvk short-lookup range facts from operational acceptance
+
+    [CommitIvkHash.commit_ivk_short_lookup_ok]
+    ([circuit_proof/ownership/commit_ivk_hash.v]) bounds the three
+    range-checked cells of the [Commit^ivk] message decomposition.  Like
+    the note-commit families it is underivable from [Holds] alone: the
+    halo2 short lookup constrains its cell only where [QRunning] is zero,
+    and the relational selector model leaves that selector free at the
+    short-range rows.
+
+    The three sites are instances of the shape the circuit's single
+    range-check lookup argument is used at everywhere, so the file adds no
+    new machinery: it pins the three sites as [ShortSite] records, checks
+    them against the reified synthesis facts, the region placement, the
+    inverse-constant identity and the pinned event stream, and feeds them
+    to [OrchardShortLookupClosure.site_short_bound].
+
+    The premises of [commit_ivk_short_lookup_ok_operational] are those of
+    [orchard_operational_sound]: replay success of the serialized Orchard
+    circuit and ideal acceptance of the resulting grid. *)
+
+Require Import Stdlib.Bool.Bool.
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.micromega.Lia.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.serialize.
+Require Import Garden.Halo2.realize.main.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.circuit_synthesis_layout.
+Require Import Garden.Orchard.circuit_proof.facts.
+Require Import Garden.Orchard.circuit_proof.lookup_closure.
+Require Import Garden.Orchard.circuit_proof.ownership.commit_ivk_hash.
+Require Import Garden.Orchard.circuit_operational.
+Require Import Garden.Halo2.realize.sound.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardCommitIvkLookupClosure.
+  Import OrchardShortLookupClosure.
+
+  (** ** The three CommitIvk short-range sites
+
+      Each region occupies three rows from its placement start: [QLookup]
+      at offsets [0] and [1], [QBitshift] at offset [1], and the [A9] cell
+      at offset [2] pinned to the inverse of [2 ^ bits]. *)
+
+  Definition site_civk_b0 : ShortSite := {|
+    ss_region := CommitIvkHash.cir RegionId.CommitIvk.RangeB0;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 1700;
+  |}.
+
+  Definition site_civk_b2 : ShortSite := {|
+    ss_region := CommitIvkHash.cir RegionId.CommitIvk.RangeB2;
+    ss_bits := 5;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_5;
+    ss_start := 1703;
+  |}.
+
+  Definition site_civk_d0 : ShortSite := {|
+    ss_region := CommitIvkHash.cir RegionId.CommitIvk.RangeD0;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 1764;
+  |}.
+
+  Definition commit_ivk_sites : list ShortSite := [
+    site_civk_b0;
+    site_civk_b2;
+    site_civk_d0
+  ].
+
+  (** ** The certificates
+
+      [site_facts_ok] reads the four synthesis facts of each region,
+      [site_start_ok] its placement row, [site_inv_ok] the width bound and
+      the field identity [2 ^ 10 * inv = 2 ^ (10 - bits)], and
+      [site_qrunning_ok] the absence of a [QRunning] enable at the two
+      lookup rows over the whole pinned event stream. *)
+
+  Lemma commit_ivk_facts_cert :
+    List.forallb site_facts_ok commit_ivk_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma commit_ivk_start_cert :
+    List.forallb site_start_ok commit_ivk_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma commit_ivk_inv_cert :
+    List.forallb site_inv_ok commit_ivk_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma commit_ivk_qrunning_cert :
+    List.forallb site_qrunning_ok commit_ivk_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  (** ** The per-site bound
+
+      [orchard_operational_sound] carries replay success and ideal
+      acceptance to the relational [circuit_holds] of the realized
+      assignment, and
+      the generic site derivation supplies the range bound the relational
+      model leaves free. *)
+
+  Lemma commit_ivk_site_bound
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (site : ShortSite) (Hin : List.In site commit_ivk_sites) :
+    0 <=
+      UnOp.from
+        (eval_cell (realize Index.indices region_start_of grid)
+          (Garden.Halo2.Synthesis.Cell.advice site.(ss_region) Advice.A9 0)) <
+      2 ^ site.(ss_bits).
+  Proof.
+    exact (site_short_bound advice instance_ grid Hreplay
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      commit_ivk_sites commit_ivk_facts_cert commit_ivk_start_cert
+      commit_ivk_inv_cert commit_ivk_qrunning_cert site Hin).
+  Qed.
+
+  (** ** The CommitIvk family, from operational acceptance *)
+
+  Theorem commit_ivk_short_lookup_ok_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    CommitIvkHash.commit_ivk_short_lookup_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    unfold CommitIvkHash.commit_ivk_short_lookup_ok,
+      NoteCommitNewWords.short_ok, NoteCommitNewWords.val,
+      NoteCommitNewWords.adv.
+    split;
+      [exact (commit_ivk_site_bound advice instance_ grid Hreplay Hmock
+        site_civk_b0
+        ltac:(unfold commit_ivk_sites;
+          repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (commit_ivk_site_bound advice instance_ grid Hreplay Hmock
+        site_civk_b2
+        ltac:(unfold commit_ivk_sites;
+          repeat (first [left; reflexivity | right]))) |].
+    exact (commit_ivk_site_bound advice instance_ grid Hreplay Hmock
+      site_civk_d0
+      ltac:(unfold commit_ivk_sites;
+        repeat (first [left; reflexivity | right]))).
+  Qed.
+End OrchardCommitIvkLookupClosure.

--- a/Garden/Orchard/circuit_proof/lookup_closure_old_note.v
+++ b/Garden/Orchard/circuit_proof/lookup_closure_old_note.v
@@ -1,0 +1,264 @@
+(** * The old-note short-lookup range facts from operational acceptance
+
+    The [Which.Old] instance of the closure proved for the new note in
+    [circuit_proof/lookup_closure.v].  The eleven short-range sites of
+    [OldNoteWords.old_note_short_lookup_ok] have the same three-row shape
+    as the [Which.New] ones — [QLookup] at offsets [0] and [1], [QBitshift]
+    at offset [1], the [A9] cell at offset [2] pinned to the inverse of
+    [2 ^ bits], and [QRunning] enabled nowhere — so the whole derivation is
+    an instantiation of [OrchardShortLookupClosure.site_short_bound] at a
+    site list carrying the [Which.Old] regions and their placement rows.
+
+    The file adds no machinery: the extraction lemma
+    ([short_range_bound]), the ten-bit lookup bound, the bitshift gate, the
+    selector-absence transport ([realized_selector_unset]) and the
+    membership reflection all come from [lookup_closure.v]; what is new is
+    the pinned site data, its four [vm_compute] certificates, and the
+    assembly of the eleven conjuncts. *)
+
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.realize.main.
+Require Import Garden.Halo2.realize.sound.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.circuit_synthesis_layout.
+Require Import Garden.Orchard.circuit_proof.lookup_closure.
+Require Import Garden.Orchard.circuit_proof.old_note.words.
+Require Import Garden.Orchard.circuit_operational.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardOldNoteLookupClosure.
+  Import OrchardShortLookupClosure.
+
+  (** ** The old-note family sites
+
+      Region, bit width, pinned inverse constant and absolute placement
+      row, one entry per conjunct of [old_note_short_lookup_ok]. *)
+
+  Definition site_old_b0 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeB0;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 655;
+  |}.
+
+  Definition site_old_b3 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeB3;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 1688;
+  |}.
+
+  Definition site_old_d2 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeD2;
+    ss_bits := 8;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_8;
+    ss_start := 1685;
+  |}.
+
+  Definition site_old_e0 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeE0;
+    ss_bits := 6;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_6;
+    ss_start := 1661;
+  |}.
+
+  Definition site_old_e1 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeE1;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 745;
+  |}.
+
+  Definition site_old_g1 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeG1;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 718;
+  |}.
+
+  Definition site_old_h0 : ShortSite := {|
+    ss_region := OldNoteWords.ncr RegionId.NoteCommit.RangeH0;
+    ss_bits := 5;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_5;
+    ss_start := 685;
+  |}.
+
+  Definition site_old_gd_k0 : ShortSite := {|
+    ss_region :=
+      OldNoteWords.nyr RegionId.NoteCommit.YSubject.GD
+        RegionId.NoteCommit.YCanonicity.RangeK0;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 673;
+  |}.
+
+  Definition site_old_gd_k2 : ShortSite := {|
+    ss_region :=
+      OldNoteWords.nyr RegionId.NoteCommit.YSubject.GD
+        RegionId.NoteCommit.YCanonicity.RangeK2;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 634;
+  |}.
+
+  Definition site_old_pkd_k0 : ShortSite := {|
+    ss_region :=
+      OldNoteWords.nyr RegionId.NoteCommit.YSubject.PkD
+        RegionId.NoteCommit.YCanonicity.RangeK0;
+    ss_bits := 9;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_9;
+    ss_start := 631;
+  |}.
+
+  Definition site_old_pkd_k2 : ShortSite := {|
+    ss_region :=
+      OldNoteWords.nyr RegionId.NoteCommit.YSubject.PkD
+        RegionId.NoteCommit.YCanonicity.RangeK2;
+    ss_bits := 4;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_4;
+    ss_start := 628;
+  |}.
+
+  Definition old_note_sites : list ShortSite := [
+    site_old_b0;
+    site_old_b3;
+    site_old_d2;
+    site_old_e0;
+    site_old_e1;
+    site_old_g1;
+    site_old_h0;
+    site_old_gd_k0;
+    site_old_gd_k2;
+    site_old_pkd_k0;
+    site_old_pkd_k2
+  ].
+
+  (** ** The certificates
+
+      The four checkers of [lookup_closure.v], at the old-note site list:
+      the four synthesis facts per site, the placement row, the inverse
+      identity with the width bound, and the absence of [QRunning] enables
+      at the two lookup rows over the whole pinned event stream. *)
+
+  Lemma old_note_facts_cert :
+    List.forallb site_facts_ok old_note_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma old_note_start_cert :
+    List.forallb site_start_ok old_note_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma old_note_inv_cert :
+    List.forallb site_inv_ok old_note_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma old_note_qrunning_cert :
+    List.forallb site_qrunning_ok old_note_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  (** ** The family, from operational acceptance
+
+      [orchard_operational_sound] carries replay success and ideal
+      acceptance to the relational [circuit_holds] of the realized
+      assignment; [site_short_bound] turns the certificates at each site
+      into the range bound the relational model leaves free. *)
+
+  Lemma old_note_site_bound
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows)
+      (site : ShortSite) (Hin : List.In site old_note_sites) :
+    0 <=
+      UnOp.from
+        (eval_cell (realize Index.indices region_start_of grid)
+          (Garden.Halo2.Synthesis.Cell.advice site.(ss_region) Advice.A9 0)) <
+      2 ^ site.(ss_bits).
+  Proof.
+    exact (site_short_bound advice instance_ grid Hreplay
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      old_note_sites old_note_facts_cert old_note_start_cert
+      old_note_inv_cert old_note_qrunning_cert site Hin).
+  Qed.
+
+  Theorem old_note_short_lookup_ok_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    OldNoteWords.old_note_short_lookup_ok
+      (realize Index.indices region_start_of grid).
+  Proof.
+    unfold OldNoteWords.old_note_short_lookup_ok, OldNoteWords.short_ok,
+      OldNoteWords.val, OldNoteWords.adv.
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_b0
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_b3
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_d2
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_e0
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_e1
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_g1
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_h0
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_gd_k0
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_gd_k2
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    split;
+      [exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+        site_old_pkd_k0
+        ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))) |].
+    exact (old_note_site_bound advice instance_ grid Hreplay Hmock
+      site_old_pkd_k2
+      ltac:(unfold old_note_sites; repeat (first [left; reflexivity | right]))).
+  Qed.
+End OrchardOldNoteLookupClosure.

--- a/Garden/Orchard/circuit_proof/merkle_bot.v
+++ b/Garden/Orchard/circuit_proof/merkle_bot.v
@@ -1644,6 +1644,6 @@ Module OrchardMerkleBot.
       Holds Γ ->
       merkle_b_range_ok Γ ->
       (forall i : Z, 0 <= i < 32 -> merkle_layer_canonical Γ i) \/
-      (exists (c0 : Z) (cs : list (Z * Z)),
-         sinsemilla_dlog_relation merkle_Q c0 cs).
+      (exists (c0 : Z) (c : Z -> Z),
+         sinsemilla_dlog_relation merkle_Q c0 c).
 End OrchardMerkleBot.

--- a/Garden/Orchard/circuit_proof/merkle_bot.v
+++ b/Garden/Orchard/circuit_proof/merkle_bot.v
@@ -1,0 +1,1649 @@
+(** * The Merkle-path clause of the adversarial Action statement
+
+    §4.18.4 'Action Statement (Orchard)', 'Merkle path validity': "Either
+    v^old = 0; or (path, pos) is a valid Merkle path of depth
+    MerkleDepth^Orchard, as defined in section 4.9 'Merkle Path Validity',
+    from Extract_P(cm^old) to the anchor rt^OrchardPool."
+
+    This file discharges [OrchardAdversarialApi.anchor_obligation] from
+    circuit acceptance with no witness-honesty hypothesis: neither the
+    per-layer incomplete-addition nondegeneracy nor the canonicity of the
+    witnessed decompositions is assumed.  The two slack sources of
+    [OrchardActionMerkle.merkle_layer_ok] are handled differently, as the
+    protocol handles them:
+
+    - the Sinsemilla exceptional cases (§5.4.1.9) become the clause's
+      second disjunct, the §4.9 escape ("the validity check is permitted
+      to be implemented in such a way that it can pass if any hash value
+      on the path, including the root, is 0"), spelled as an existential
+      over the 32 layers of a ⊥ fold;
+    - the wrapped-decomposition slack is absorbed into the *witnessed*
+      reading of path validity licensed by the §4.18.4 note ("each layer
+      does not check that its input bit sequence is a canonical encoding
+      (in {0 .. q_P − 1}) of the integer from the previous layer"): each
+      layer hashes a [merkle_message] of an integer pair only congruent
+      mod [p] to the running node and the witnessed sibling.
+
+    The middle conjunct of [OrchardActionMerkle.merkle_layer_canonical] is
+    not slack at all and is derived outright: the [b_1] and [b_2] pieces
+    are 5-bit short-lookup sites, so [b_1 + b_2·2^5 < 2^10 < p] follows
+    from operational acceptance through the [ShortSite] machinery of
+    [circuit_proof/lookup_closure.v].  Only the two 255-bit
+    reconstructions stay in the congruence reading. *)
+
+Require Import Stdlib.Bool.Bool.
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.micromega.Lia.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.serialize.
+Require Import Garden.Halo2.realize.main.
+Require Import Garden.Halo2.realize.sound.
+Require Import Garden.Halo2.PallasModel.
+Require Import Garden.EllipticCurve.Pallas.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.chip_proof.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_fold_proof.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.merkle.chip_proof.
+Require Import Garden.Halo2.halo2_gadgets.utilities.cond_swap_proof.
+Require Import Garden.Halo2.halo2_gadgets.utilities_proof.
+Require Import Garden.Field.Lemmas.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.decidable_eq.
+Require Import Garden.Orchard.circuit_synthesis_layout.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.facts.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.merkle.
+Require Import Garden.Orchard.circuit_proof.bridges.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial_api.
+Require Import Garden.Orchard.circuit_proof.lookup_closure.
+Require Import Garden.Orchard.circuit_operational.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardMerkleBot.
+  Import OrchardActionInputs.
+  Import OrchardActionMerkle.
+  Import OrchardProtocolSpecBot.
+  Import OrchardAdversarialApi.
+  Import OrchardShortLookupClosure.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** ** The 64 [b_1]/[b_2] short-lookup sites
+
+      [circuit.synthesize_merkle_hash_layer_{1,2}] range-checks both
+      pieces with the shared short-lookup gadget
+      ([lookup_range_check.synthesize_short], width 5, inverse constant
+      [inv_two_pow_5], checked cell [A9] at offset 0) — the same gadget,
+      column and three-row shape as the eleven note-commitment sites.  The
+      sites are therefore a plain instantiation of the [ShortSite]
+      machinery; the placement row is spelled as the layout function
+      itself, so [site_start_ok] is a computation rather than a pinned
+      literal. *)
+
+  Definition site_merkle_b1 (layer : Z) : ShortSite := {|
+    ss_region :=
+      Garden.Orchard.circuit.merkle_region layer
+        RegionId.Merkle.Region.RangeB1;
+    ss_bits := 5;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_5;
+    ss_start :=
+      region_start_of
+        (Garden.Orchard.circuit.merkle_region layer
+          RegionId.Merkle.Region.RangeB1);
+  |}.
+
+  Definition site_merkle_b2 (layer : Z) : ShortSite := {|
+    ss_region :=
+      Garden.Orchard.circuit.merkle_region layer
+        RegionId.Merkle.Region.RangeB2;
+    ss_bits := 5;
+    ss_inv := Garden.Halo2.halo2_gadgets.ecc.chip.constants.inv_two_pow_5;
+    ss_start :=
+      region_start_of
+        (Garden.Orchard.circuit.merkle_region layer
+          RegionId.Merkle.Region.RangeB2);
+  |}.
+
+  Definition merkle_sites : list ShortSite :=
+    List.map (fun n : nat => site_merkle_b1 (Z.of_nat n))
+      (List.seq 0%nat 32%nat) ++
+    List.map (fun n : nat => site_merkle_b2 (Z.of_nat n))
+      (List.seq 0%nat 32%nat).
+
+  Lemma merkle_facts_cert :
+    List.forallb site_facts_ok merkle_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma merkle_start_cert :
+    List.forallb site_start_ok merkle_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma merkle_inv_cert :
+    List.forallb site_inv_ok merkle_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  Lemma merkle_qrunning_cert :
+    List.forallb site_qrunning_ok merkle_sites = true.
+  Proof.
+    vm_cast_no_check (@eq_refl bool true).
+  Qed.
+
+  (** Layer membership: every layer index in range is [Z.of_nat] of an
+      element of [seq 0 32]. *)
+  Lemma in_layer_seq (i : Z) (Hi : 0 <= i < 32) {A : Type} (f : Z -> A) :
+    List.In (f i) (List.map (fun n : nat => f (Z.of_nat n))
+      (List.seq 0%nat 32%nat)).
+  Proof.
+    apply List.in_map_iff.
+    exists (Z.to_nat i).
+    split.
+    - f_equal. lia.
+    - apply List.in_seq. lia.
+  Qed.
+
+  Lemma site_merkle_b1_in (i : Z) (Hi : 0 <= i < 32) :
+    List.In (site_merkle_b1 i) merkle_sites.
+  Proof.
+    unfold merkle_sites.
+    apply List.in_or_app.
+    left.
+    exact (in_layer_seq i Hi site_merkle_b1).
+  Qed.
+
+  Lemma site_merkle_b2_in (i : Z) (Hi : 0 <= i < 32) :
+    List.In (site_merkle_b2 i) merkle_sites.
+  Proof.
+    unfold merkle_sites.
+    apply List.in_or_app.
+    right.
+    exact (in_layer_seq i Hi site_merkle_b2).
+  Qed.
+
+  (** ** [merkle_b_range_ok] from operational acceptance *)
+
+  Theorem merkle_b_range_ok_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    merkle_b_range_ok (realize Index.indices region_start_of grid).
+  Proof.
+    pose proof (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      as Hcircuit.
+    intros i Hi.
+    split.
+    - exact (site_short_bound advice instance_ grid Hreplay Hcircuit
+        merkle_sites merkle_facts_cert merkle_start_cert merkle_inv_cert
+        merkle_qrunning_cert (site_merkle_b1 i) (site_merkle_b1_in i Hi)).
+    - exact (site_short_bound advice instance_ grid Hreplay Hcircuit
+        merkle_sites merkle_facts_cert merkle_start_cert merkle_inv_cert
+        merkle_qrunning_cert (site_merkle_b2 i) (site_merkle_b2_in i Hi)).
+  Qed.
+
+  (** The middle conjunct of [OrchardActionMerkle.merkle_layer_canonical],
+      derived rather than assumed: two 5-bit pieces reconstruct below
+      [2^10], far below [p].  The two 255-bit reconstructions (conjuncts 1
+      and 3) are the slack and stay absorbed in the witnessed
+      reading. *)
+  Lemma merkle_layer_canonical_middle
+      (Γ : Assignment.t columns RegionId.t)
+      (Hb : merkle_b_range_ok Γ)
+      (i : Z) (Hi : 0 <= i < 32) :
+    UnOp.from (eval_cell Γ (Garden.Halo2.Synthesis.Cell.advice
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB1)
+        Advice.A9 0)) +
+      UnOp.from (eval_cell Γ (Garden.Halo2.Synthesis.Cell.advice
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB2)
+        Advice.A9 0)) * 2 ^ 5
+      < Primes.pallas_p.
+  Proof.
+    destruct (Hb i Hi) as [Hb1 Hb2].
+    change (2 ^ 5) with 32 in *.
+    pose proof pallas_p_big as Hp.
+    change (2 ^ 20) with 1048576 in Hp.
+    lia.
+  Qed.
+
+  (** ** The canonicity-free per-layer core
+
+      [OrchardActionMerkle.merkle_hash_layer_core] promotes the
+      decomposition gate's mod-[p] identities to integer identities using
+      all three canonicity conjuncts, and concludes the layer output is
+      [merkle_crh] of the *node and sibling values*.  The variant below
+      drops that promotion: it concludes (i) the layer output is the
+      Sinsemilla hash (§5.4.1.9) of the region's own 52 words — no
+      decomposition reasoning at all — and (ii) those 52 words are a
+      [merkle_message] (the §5.4.1.3 MerkleCRH layout) of
+      an integer pair whose residues are the decomposition gate's
+      [left_node] and [right_node] cells.  Only the middle canonicity
+      conjunct is used, in the sharper [ShortSite] form ([b_1], [b_2]
+      below [2^5]), and it enters solely to identify the [b] piece's
+      running-sum word with [b_1 + b_2·2^5].
+
+      This is the §4.18.4 note "each layer does not check that its input
+      bit sequence is a canonical encoding (in {0 .. q_P − 1}) of the
+      integer from the previous layer", made explicit: the witnessed pair
+      is congruent mod [p] to the node/sibling pair and need not be its
+      canonical 255-bit encoding. *)
+  Lemma merkle_hash_layer_fold
+      (Γ : Assignment.t columns RegionId.t)
+      (q1 : Selector.t) (q2 : Fixed.t)
+      (x_a x_p bits lambda_1 lambda_2 : Advice.t)
+      (H : RegionId.t)
+      (i left right beta1 beta2 : Z)
+      (Hi : 0 <= i < 32)
+      (Hload : interpret_facts Γ (layouter_facts
+        Garden.Halo2.halo2_gadgets.sinsemilla.chip.load_generator_table))
+      (Hsel : forall j : nat, (j < 52)%nat ->
+        Γ ⊢ ⟦ Expression.Selector q1 ⟧ (H, Z.of_nat j) = 1)
+      (Hgate : forall row : Z,
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_gate
+          q1 q2 x_a x_p lambda_1 lambda_2 ⟧ (H, row))
+      (Hlookup : forall row : Z,
+        eval_lookup_argument Γ (H, row) GeneratorTable.table_rows
+          (Garden.Halo2.halo2_gadgets.sinsemilla.chip.generator_table_argument
+            q1 q2 x_a x_p bits lambda_1 lambda_2))
+      (Hq2_one : forall j : nat,
+        (j < 52)%nat -> j <> 24%nat -> j <> 26%nat -> j <> 51%nat ->
+        Γ.(Assignment.fixed) q2 H (Z.of_nat j) = 1)
+      (Hq2_24 : Γ.(Assignment.fixed) q2 H 24 = 0)
+      (Hq2_26 : Γ.(Assignment.fixed) q2 H 26 = 0)
+      (Hq2_51 : Γ.(Assignment.fixed) q2 H 51 = 2)
+      (Hacc0 : SinsemillaHash.acc_at Γ x_a x_p lambda_1 lambda_2 H 0 = merkle_Q)
+      (Hnondeg : SinsemillaHash.nondegenerate merkle_Q
+        (SinsemillaHash.hash_words Γ q2 bits H 52))
+      (Hbeta1_small : 0 <= beta1 < 2 ^ 5)
+      (Hbeta2_small : 0 <= beta2 < 2 ^ 5)
+      (Hdec :
+        {|
+          DecompositionCheck.l_whole := UnOp.from i;
+          DecompositionCheck.left_node := left;
+          DecompositionCheck.right_node := right;
+          DecompositionCheck.z1_b :=
+            Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 26);
+        |} =
+          DecompositionCheck.output
+            (Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 0))
+            (Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 25))
+            (Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 27))
+            (Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 1))
+            beta1
+            beta2) :
+    Γ ⊢ ⟦ Expression.Advice x_a Rotation.cur ⟧ (H, 52) =
+      EccSpec.extract_x
+        (SinsemillaSpec.sinsemilla_hash_to_point merkle_Q
+          (SinsemillaHash.hash_words Γ q2 bits H 52)) /\
+    exists l r : Z,
+      SinsemillaHash.hash_words Γ q2 bits H 52 =
+        SinsemillaSpec.merkle_message i l r /\
+      UnOp.from l = left /\
+      UnOp.from r = right.
+  Proof.
+    (* Row schedule: [q_s3 = 0] below the final row, [q_s3 = 2] on row 51. *)
+    assert (Hq3 : forall j : nat, (S j < 52)%nat ->
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.q_s3 q2 ⟧
+          (H, Z.of_nat j) = 0).
+    { intros j Hj.
+      destruct (Nat.eq_dec j 24) as [-> | Hj24].
+      - apply (q_s3_eval_zero Γ q2 H (Z.of_nat 24) 0);
+          [exact Hq2_24 | left; reflexivity].
+      - destruct (Nat.eq_dec j 26) as [-> | Hj26].
+        + apply (q_s3_eval_zero Γ q2 H (Z.of_nat 26) 0);
+            [exact Hq2_26 | left; reflexivity].
+        + apply (q_s3_eval_zero Γ q2 H (Z.of_nat j) 1);
+            [apply Hq2_one; lia | right; reflexivity]. }
+    assert (Hq3_final :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.q_s3 q2 ⟧
+          (H, Z.of_nat (52 - 1)) = 2).
+    { apply q_s3_eval_two. exact Hq2_51. }
+    (* The 52-round point fold. *)
+    pose proof (SinsemillaHashFold.hash_to_point_rows_correct Γ H q1 q2
+        x_a x_p bits lambda_1 lambda_2 52 ltac:(lia) merkle_Q
+        Hload Hsel (fun j _ => Hgate (Z.of_nat j))
+        (fun j _ => Hlookup (Z.of_nat j))
+        Hq3 Hq3_final Hacc0 Hnondeg) as Hpoint.
+    assert (Hbound : forall j : nat, (j < 52)%nat ->
+        0 <= SinsemillaHash.word_at Γ q2 bits H (Z.of_nat j) < 2 ^ 10).
+    { intros j Hj.
+      apply (word_at_bound Γ H (Z.of_nat j) q1 q2 x_a x_p bits lambda_1
+        lambda_2 Hload (Hsel j Hj) (Hlookup (Z.of_nat j))). }
+    (* The output-cell reading.  [rewrite <- Hpoint] first: matching a
+       projection of the fold against a constant application would send
+       the 52-round symbolic fold to unification. *)
+    split.
+    { unfold EccSpec.extract_x.
+      rewrite <- Hpoint.
+      cbn [Point.x].
+      change (Z.of_nat 52) with 52.
+      reflexivity. }
+    (* The four piece telescopes (a at 0, its z1 tail at 1, b at 25, c at
+       27) and the b-piece's z1 cell. *)
+    assert (HA : Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 0) =
+        SinsemillaHash.digit_sum (List.map
+          (fun j : nat => SinsemillaHash.word_at Γ q2 bits H (0 + Z.of_nat j))
+          (List.seq 0%nat 25%nat))).
+    { apply SinsemillaHash.piece_telescope.
+      - lia.
+      - intros j Hj.
+        replace (0 + Z.of_nat j) with (Z.of_nat j) by lia.
+        apply word_at_step.
+        apply Hq2_one; lia.
+      - replace (0 + Z.of_nat (25 - 1)) with (Z.of_nat 24) by lia.
+        apply (word_at_last Γ q2 bits H (Z.of_nat 24) 0);
+          [exact Hq2_24 | left; reflexivity].
+      - intros j Hj.
+        replace (0 + Z.of_nat j) with (Z.of_nat j) by lia.
+        apply Hbound; lia.
+      - lia. }
+    assert (HA1 : Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 1) =
+        SinsemillaHash.digit_sum (List.map
+          (fun j : nat => SinsemillaHash.word_at Γ q2 bits H (1 + Z.of_nat j))
+          (List.seq 0%nat 24%nat))).
+    { apply SinsemillaHash.piece_telescope.
+      - lia.
+      - intros j Hj.
+        replace (1 + Z.of_nat j) with (Z.of_nat (S j)) by lia.
+        apply word_at_step.
+        apply Hq2_one; lia.
+      - replace (1 + Z.of_nat (24 - 1)) with (Z.of_nat 24) by lia.
+        apply (word_at_last Γ q2 bits H (Z.of_nat 24) 0);
+          [exact Hq2_24 | left; reflexivity].
+      - intros j Hj.
+        replace (1 + Z.of_nat j) with (Z.of_nat (S j)) by lia.
+        apply Hbound; lia.
+      - lia. }
+    assert (HB : Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 25) =
+        SinsemillaHash.digit_sum (List.map
+          (fun j : nat => SinsemillaHash.word_at Γ q2 bits H (25 + Z.of_nat j))
+          (List.seq 0%nat 2%nat))).
+    { apply SinsemillaHash.piece_telescope.
+      - lia.
+      - intros j Hj.
+        replace (25 + Z.of_nat j) with (Z.of_nat 25) by lia.
+        apply word_at_step.
+        apply Hq2_one; lia.
+      - replace (25 + Z.of_nat (2 - 1)) with (Z.of_nat 26) by lia.
+        apply (word_at_last Γ q2 bits H (Z.of_nat 26) 0);
+          [exact Hq2_26 | left; reflexivity].
+      - intros j Hj.
+        replace (25 + Z.of_nat j) with (Z.of_nat (25 + j)) by lia.
+        apply Hbound; lia.
+      - lia. }
+    assert (HC : Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 27) =
+        SinsemillaHash.digit_sum (List.map
+          (fun j : nat => SinsemillaHash.word_at Γ q2 bits H (27 + Z.of_nat j))
+          (List.seq 0%nat 25%nat))).
+    { apply SinsemillaHash.piece_telescope.
+      - lia.
+      - intros j Hj.
+        replace (27 + Z.of_nat j) with (Z.of_nat (27 + j)) by lia.
+        apply word_at_step.
+        apply Hq2_one; lia.
+      - replace (27 + Z.of_nat (25 - 1)) with (Z.of_nat 51) by lia.
+        apply (word_at_last Γ q2 bits H (Z.of_nat 51) 2);
+          [exact Hq2_51 | right; reflexivity].
+      - intros j Hj.
+        replace (27 + Z.of_nat j) with (Z.of_nat (27 + j)) by lia.
+        apply Hbound; lia.
+      - lia. }
+    assert (HB1 : Γ ⊢ ⟦ Expression.Advice bits Rotation.cur ⟧ (H, 26) =
+        SinsemillaHash.word_at Γ q2 bits H 26).
+    { apply (word_at_last Γ q2 bits H 26 0);
+        [exact Hq2_26 | left; reflexivity]. }
+    set (w := SinsemillaHash.word_at Γ q2 bits H) in *.
+    set (dsA := SinsemillaHash.digit_sum
+      (List.map (fun j : nat => w (0 + Z.of_nat j)) (List.seq 0%nat 25%nat)))
+      in *.
+    set (dsA1 := SinsemillaHash.digit_sum
+      (List.map (fun j : nat => w (1 + Z.of_nat j)) (List.seq 0%nat 24%nat)))
+      in *.
+    set (dsB := SinsemillaHash.digit_sum
+      (List.map (fun j : nat => w (25 + Z.of_nat j)) (List.seq 0%nat 2%nat)))
+      in *.
+    set (dsC := SinsemillaHash.digit_sum
+      (List.map (fun j : nat => w (27 + Z.of_nat j)) (List.seq 0%nat 25%nat)))
+      in *.
+    (* Structural digit-sum identities and bounds. *)
+    assert (HheadA : dsA = w 0 + 2 ^ 10 * dsA1).
+    { unfold dsA, w.
+      rewrite (SinsemillaHash.digit_sum_words_head Γ q2 bits H 0 24%nat).
+      unfold dsA1, w.
+      f_equal. }
+    assert (HdsB : dsB = w 25 + 2 ^ 10 * w 26).
+    { unfold dsB.
+      cbn [List.seq List.map SinsemillaHash.digit_sum].
+      replace (25 + Z.of_nat 0) with 25 by lia.
+      replace (25 + Z.of_nat 1) with 26 by lia.
+      lia. }
+    assert (HboundA1 : 0 <= dsA1 < 2 ^ 240).
+    { unfold dsA1.
+      pose proof (SinsemillaHash.digit_sum_bound
+        (List.map (fun j : nat => w (1 + Z.of_nat j)) (List.seq 0%nat 24%nat)))
+        as Hb.
+      rewrite List.length_map, List.length_seq in Hb.
+      apply Hb.
+      rewrite List.Forall_map, List.Forall_forall.
+      intros j Hj. rewrite List.in_seq in Hj.
+      replace (1 + Z.of_nat j) with (Z.of_nat (S j)) by lia.
+      apply Hbound. lia. }
+    assert (Hw0 : 0 <= w 0 < 2 ^ 10) by (apply (Hbound 0%nat); lia).
+    (* The decomposition-gate components.  [Hl] is promoted to an integer
+       identity by the layer index's own range; [Hz1b] by the two 5-bit
+       lookup bounds.  [Hleft] and [Hright] are kept as the mod-[p]
+       identities they are — the witnessed reading. *)
+    pose proof (f_equal DecompositionCheck.l_whole Hdec) as Hl.
+    pose proof (f_equal DecompositionCheck.left_node Hdec) as Hleft.
+    pose proof (f_equal DecompositionCheck.right_node Hdec) as Hright.
+    pose proof (f_equal DecompositionCheck.z1_b Hdec) as Hz1b.
+    unfold DecompositionCheck.output in Hl, Hleft, Hright, Hz1b.
+    cbn [DecompositionCheck.l_whole DecompositionCheck.left_node
+      DecompositionCheck.right_node DecompositionCheck.z1_b]
+      in Hl, Hleft, Hright, Hz1b.
+    rewrite HA, HA1 in Hl.
+    rewrite HA1, HB in Hleft.
+    rewrite HC in Hright.
+    rewrite HB1 in Hz1b.
+    clear Hdec.
+    assert (Hw26_int : w 26 = beta1 + beta2 * 2 ^ 5)
+      by (clear -Hz1b Hbeta1_small Hbeta2_small; field_solve).
+    assert (Hi_int : i = w 0)
+      by (clear -Hl HheadA HboundA1 Hw0 Hi; field_solve).
+    (* The witnessed pair: the two reconstructions read as integers, with
+       no wrap assumption. *)
+    exists (dsA1 + (w 25 + beta1 * 2 ^ 10) * 2 ^ 240),
+      (beta2 + dsC * 2 ^ 5).
+    (* Message identification: the 52 row words are exactly
+       [merkle_message i left' right']. *)
+    assert (Hsplit : SinsemillaHash.hash_words Γ q2 bits H 52 =
+      List.map (fun j : nat => w (0 + Z.of_nat j)) (List.seq 0%nat 25%nat) ++
+      List.map (fun j : nat => w (25 + Z.of_nat j)) (List.seq 0%nat 2%nat) ++
+      List.map (fun j : nat => w (27 + Z.of_nat j)) (List.seq 0%nat 25%nat)).
+    { unfold SinsemillaHash.hash_words.
+      transitivity (List.map (fun j : nat => w (0 + Z.of_nat j))
+        (List.seq 0%nat (25 + 27)%nat)); [reflexivity |].
+      rewrite (map_z_seq_split w 0 25 27).
+      f_equal. }
+    assert (Hall52 : List.Forall (fun x : Z => 0 <= x < 2 ^ 10)
+        (SinsemillaHash.hash_words Γ q2 bits H 52)).
+    { unfold SinsemillaHash.hash_words.
+      rewrite List.Forall_map, List.Forall_forall.
+      intros j Hj. rewrite List.in_seq in Hj.
+      apply Hbound. lia. }
+    assert (Hpack :
+      i + (dsA1 + (w 25 + beta1 * 2 ^ 10) * 2 ^ 240) * 2 ^ 10 +
+        (beta2 + dsC * 2 ^ 5) * 2 ^ 265 =
+      SinsemillaHash.digit_sum (SinsemillaHash.hash_words Γ q2 bits H 52)).
+    { rewrite Hsplit.
+      rewrite !SinsemillaHash.digit_sum_app.
+      rewrite !List.length_map, !List.length_seq.
+      replace (10 * Z.of_nat 25) with 250 by lia.
+      replace (10 * Z.of_nat 2) with 20 by lia.
+      fold dsA dsB dsC.
+      clear -Hi_int HheadA HdsB Hw26_int.
+      lia. }
+    split; [| split].
+    - unfold SinsemillaSpec.merkle_message.
+      change SinsemillaSpec.sinsemilla_k with 10.
+      replace (10 + 255) with 265 by lia.
+      rewrite Hpack.
+      pose proof (SinsemillaHash.words_le_digit_sum _ Hall52) as Hw52.
+      rewrite SinsemillaHash.hash_words_length in Hw52.
+      symmetry.
+      exact Hw52.
+    - rewrite Hleft, HdsB, Hw26_int.
+      mod_ring_solve.
+    - rewrite Hright.
+      mod_ring_solve.
+  Qed.
+
+  (** ** The per-layer statement, variant 1 (layers 0–15)
+
+      The region navigation is that of
+      [OrchardActionMerkle.merkle_layer_correct_1]; only the core it feeds
+      and the conclusion differ.  The layer's output cell is the
+      Sinsemilla hash of the region's own message, and that message is a
+      [merkle_message] (§5.4.1.3 MerkleCRH) of a pair whose residues are
+      the cond-swapped (node, sibling) pair — the witnessed reading. *)
+  Lemma merkle_layer_bot_1
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (i : Z) (Hi : 0 <= i < 32) (Hlt : (i <? 16) = true)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      (Hfacts : interpret_facts Γ (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node)))
+      (Hb : merkle_b_range_ok Γ)
+      (Hnondeg : SinsemillaHash.nondegenerate merkle_Q (merkle_words Γ i)) :
+    UnOp.from (eval_cell Γ (layouter_value
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node))) =
+      EccSpec.extract_x
+        (SinsemillaSpec.sinsemilla_hash_to_point merkle_Q
+          (merkle_words Γ i)) /\
+    exists l r : Z,
+      merkle_words Γ i = SinsemillaSpec.merkle_message i l r /\
+      UnOp.from l =
+        (if read4 Γ (NP i) =? 1
+         then read1 Γ (NP i)
+         else UnOp.from (eval_cell Γ node)) /\
+      UnOp.from r =
+        (if read4 Γ (NP i) =? 1
+         then UnOp.from (eval_cell Γ node)
+         else read1 Γ (NP i)).
+  Proof.
+    pose proof (holds_gates Γ Hcircuit) as Hgates.
+    pose proof (generator_table_facts Γ Hcircuit) as Hload.
+    destruct (Hb i Hi) as [Hb1 Hb2].
+    cbn [eval_cell Garden.Halo2.Synthesis.Cell.advice
+      Garden.Halo2.Synthesis.Cell.column Garden.Halo2.Synthesis.Cell.region
+      Garden.Halo2.Synthesis.Cell.row_offset] in Hb1, Hb2.
+    unfold Garden.Orchard.circuit.synthesize_merkle_layer in Hfacts |- *.
+    rewrite Hlt in Hfacts |- *.
+    unfold merkle_words, merkle_bits, merkle_q2, HTP in Hnondeg |- *.
+    rewrite Hlt in Hnondeg |- *.
+    (* Facts of the node-position region: selector and node copy. *)
+    pose proof Hfacts as Hnp.
+    apply interpret_layouter_facts_bind_left in Hnp.
+    unfold Garden.Orchard.circuit.synthesize_node_position_1,
+      Garden.Orchard.circuit.synthesize_node_position_instance in Hnp.
+    apply interpret_layouter_facts_in_namespace in Hnp.
+    apply interpret_layouter_facts_add_region in Hnp.
+    cbn [region_facts region_value Monad.bind Monad.ret
+      Garden.Halo2.Synthesis.RegionIsMonad List.app
+      interpret_facts interpret_fact] in Hnp.
+    destruct Hnp as (HselNP & Hcopy_node & _).
+    (* Facts of the hash layer: hash region and decomposition region. *)
+    pose proof Hfacts as Hh.
+    apply interpret_layouter_facts_bind_right in Hh.
+    unfold Garden.Orchard.circuit.synthesize_merkle_hash_layer_1 in Hh.
+    apply interpret_layouter_facts_in_namespace in Hh.
+    do 5 apply interpret_layouter_facts_bind_right in Hh.
+    pose proof Hh as Hhash.
+    apply interpret_layouter_facts_bind_left in Hhash.
+    apply interpret_layouter_facts_in_namespace in Hhash.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_to_point_1
+      in Hhash.
+    apply interpret_layouter_facts_add_region in Hhash.
+    pose proof Hh as Hdecf.
+    apply interpret_layouter_facts_bind_right,
+      interpret_layouter_facts_bind_left in Hdecf.
+    unfold Garden.Orchard.circuit.synthesize_merkle_decomposition_1,
+      Garden.Orchard.circuit.synthesize_merkle_decomposition_instance in Hdecf.
+    apply interpret_layouter_facts_add_region in Hdecf.
+    cbn [region_facts region_value layouter_value Monad.bind Monad.ret
+      Garden.Halo2.Synthesis.RegionIsMonad
+      Garden.Halo2.Synthesis.LayouterIsMonad
+      List.app interpret_facts interpret_fact] in Hdecf.
+    destruct Hdecf as (HselD & Hc_a & Hc_b & Hc_c & Hc_left & Hc_right &
+      Hc_z1a & Hc_z1b & Hc_b1 & Hc_b2 & Hconst_l & _).
+    cbn in Hc_a, Hc_b, Hc_c, Hc_left, Hc_right, Hc_z1a, Hc_z1b, Hc_b1, Hc_b2.
+    clear Hfacts Hh.
+    (* Hash-region facts: seed selector/fixed/constant, per-piece schedules
+       and piece copies. *)
+    pose proof Hhash as HselY.
+    apply interpret_region_facts_bind_left in HselY.
+    cbn [region_facts interpret_facts interpret_fact] in HselY.
+    destruct HselY as [HselY _].
+    pose proof Hhash as HfixY.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in HfixY.
+    cbn [region_facts interpret_facts interpret_fact] in HfixY.
+    destruct HfixY as [HfixY _].
+    pose proof Hhash as HconstX.
+    do 2 apply interpret_region_facts_bind_right in HconstX.
+    apply interpret_region_facts_bind_left in HconstX.
+    cbn [region_facts interpret_facts interpret_fact] in HconstX.
+    destruct HconstX as [HconstX _].
+    pose proof Hhash as HpieceA.
+    do 3 apply interpret_region_facts_bind_right in HpieceA.
+    apply interpret_region_facts_bind_left in HpieceA.
+    pose proof Hhash as HpieceB.
+    do 4 apply interpret_region_facts_bind_right in HpieceB.
+    apply interpret_region_facts_bind_left in HpieceB.
+    pose proof Hhash as HpieceC.
+    do 5 apply interpret_region_facts_bind_right in HpieceC.
+    apply interpret_region_facts_bind_left in HpieceC.
+    clear Hhash.
+    pose proof HpieceA as HselA.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselA.
+    apply interpret_region_facts_bind_left in HselA.
+    pose proof HpieceA as Hq2A.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2A.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2A.
+    pose proof HpieceA as HcopyA.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyA.
+    do 2 apply interpret_region_facts_bind_right in HcopyA.
+    apply interpret_region_facts_bind_left in HcopyA.
+    cbn in HcopyA.
+    destruct HcopyA as [HcopyA _].
+    pose proof HpieceB as HselB.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselB.
+    apply interpret_region_facts_bind_left in HselB.
+    pose proof HpieceB as Hq2B.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2B.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2B.
+    pose proof HpieceB as HcopyB.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyB.
+    do 2 apply interpret_region_facts_bind_right in HcopyB.
+    apply interpret_region_facts_bind_left in HcopyB.
+    cbn in HcopyB.
+    destruct HcopyB as [HcopyB _].
+    pose proof HpieceC as HselC.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselC.
+    apply interpret_region_facts_bind_left in HselC.
+    pose proof HpieceC as Hq2C.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2C.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2C.
+    pose proof HpieceC as HcopyC.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyC.
+    do 2 apply interpret_region_facts_bind_right in HcopyC.
+    apply interpret_region_facts_bind_left in HcopyC.
+    cbn in HcopyC.
+    destruct HcopyC as [HcopyC _].
+    clear HpieceA HpieceB HpieceC.
+    (* Row schedules assembled across the three pieces. *)
+    assert (Hsel : forall j : nat, (j < 52)%nat ->
+        Γ ⊢ ⟦ Expression.Selector Selector.QSinsemilla1_1 ⟧
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.HashToPoint,
+            Z.of_nat j) = 1).
+    { intros j Hj.
+      apply SinsemillaHash.enabled_eq_one.
+      destruct (Nat.lt_ge_cases j 25) as [Hj25 | Hj25].
+      - pose proof (interpret_facts_In Γ _ _ HselA
+          (enable_selector_rows_fact _ Selector.QSinsemilla1_1 0 25 j Hj25))
+          as Hf.
+        cbn [interpret_fact] in Hf.
+        replace (Z.of_nat j) with (0 + Z.of_nat j) by lia.
+        exact Hf.
+      - destruct (Nat.lt_ge_cases j 27) as [Hj27 | Hj27].
+        + pose proof (interpret_facts_In Γ _ _ HselB
+            (enable_selector_rows_fact _ Selector.QSinsemilla1_1 25 2 (j - 25)
+              ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (25 + Z.of_nat (j - 25)) by lia.
+          exact Hf.
+        + pose proof (interpret_facts_In Γ _ _ HselC
+            (enable_selector_rows_fact _ Selector.QSinsemilla1_1 27 25 (j - 27)
+              ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (27 + Z.of_nat (j - 27)) by lia.
+          exact Hf. }
+    assert (Hq2_one : forall j : nat,
+        (j < 52)%nat -> j <> 24%nat -> j <> 26%nat -> j <> 51%nat ->
+        Γ.(Assignment.fixed) Fixed.QSinsemilla2_1
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.HashToPoint)
+          (Z.of_nat j) = 1).
+    { intros j Hj H24 H26 H51.
+      destruct (Nat.lt_ge_cases j 25) as [Hj25 | Hj25].
+      - pose proof (interpret_facts_In Γ _ _ Hq2A
+          (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_1 0 25 j false
+            ltac:(lia))) as Hf.
+        cbn [interpret_fact] in Hf.
+        replace (Z.of_nat j) with (0 + Z.of_nat j) by lia.
+        exact Hf.
+      - destruct (Nat.lt_ge_cases j 27) as [Hj27 | Hj27].
+        + pose proof (interpret_facts_In Γ _ _ Hq2B
+            (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_1 25 2 (j - 25)
+              false ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (25 + Z.of_nat (j - 25)) by lia.
+          exact Hf.
+        + pose proof (interpret_facts_In Γ _ _ Hq2C
+            (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_1 27 25 (j - 27)
+              true ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (27 + Z.of_nat (j - 27)) by lia.
+          exact Hf. }
+    assert (Hq2_24 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_1
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        24 = 0).
+    { pose proof (interpret_facts_In Γ _ _ Hq2A
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_1 0 25 false
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (0 + Z.of_nat (25 - 1)) with 24 in Hf by lia.
+      exact Hf. }
+    assert (Hq2_26 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_1
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        26 = 0).
+    { pose proof (interpret_facts_In Γ _ _ Hq2B
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_1 25 2 false
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (25 + Z.of_nat (2 - 1)) with 26 in Hf by lia.
+      exact Hf. }
+    assert (Hq2_51 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_1
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        51 = 2).
+    { pose proof (interpret_facts_In Γ _ _ Hq2C
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_1 27 25 true
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (27 + Z.of_nat (25 - 1)) with 51 in Hf by lia.
+      exact Hf. }
+    clear HselA HselB HselC Hq2A Hq2B Hq2C.
+    (* The four gates of the layer, from [satisfies_gates]. *)
+    assert (Hgate_sin : forall row : Z,
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_gate
+          Selector.QSinsemilla1_1 Fixed.QSinsemilla2_1
+          Advice.A0 Advice.A1 Advice.A3 Advice.A4 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint,
+          row)).
+    { intros row.
+      apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_gate
+          Selector.QSinsemilla1_1 Fixed.QSinsemilla2_1
+          Advice.A0 Advice.A1 Advice.A3 Advice.A4)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_yq :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.initial_y_q_gate
+          Selector.QSinsemilla4_1 Fixed.LagrangeCoeffs0
+          Advice.A0 Advice.A1 Advice.A3 Advice.A4 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.chip.initial_y_q_gate
+          Selector.QSinsemilla4_1 Fixed.LagrangeCoeffs0
+          Advice.A0 Advice.A1 Advice.A3 Advice.A4)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_cs :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+          Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+          Advice.A4 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+          Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+          Advice.A4)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_dec :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.merkle.chip
+            .decomposition_check_gate
+          Selector.QMerkleDecompose1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+          Advice.A4 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.merkle.chip
+          .decomposition_check_gate
+          Selector.QMerkleDecompose1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+          Advice.A4)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    (* Seed: the accumulator at row 0 is the domain point. *)
+    pose proof (InitialYQ.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        0 Selector.QSinsemilla4_1 Fixed.LagrangeCoeffs0
+        Advice.A0 Advice.A1 Advice.A3 Advice.A4
+        (enabled_nonzero Γ Selector.QSinsemilla4_1 _ 0 HselY) Hgate_yq) as Hy.
+    rewrite (fixed_expression_eq Γ Fixed.LagrangeCoeffs0 _ 0
+      Garden.Orchard.circuit.merkle_q_y HfixY) in Hy.
+    pose proof (SinsemillaHash.acc_at_init Γ Advice.A0 Advice.A1 Advice.A3
+      Advice.A4 _ 0 (UnOp.from Garden.Orchard.circuit.merkle_q_y) Hy) as Hacc0.
+    rewrite (eval_advice_cur_cell Γ _ Advice.A0 0) in Hacc0.
+    rewrite HconstX in Hacc0.
+    rewrite merkle_q_x_reduced in Hacc0.
+    rewrite FieldRewrite.from_from in Hacc0.
+    rewrite merkle_q_y_reduced in Hacc0.
+    (* The decomposition-gate record, routed through the copies to the hash
+       region's running-sum cells and the range/swap cells. *)
+    pose proof (DecompositionCheck.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition)
+        0 Selector.QMerkleDecompose1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+        Advice.A4
+        (enabled_nonzero Γ Selector.QMerkleDecompose1 _ 0 HselD) Hgate_dec)
+      as Hdec.
+    cbn in Hconst_l.
+    rewrite !(eval_advice_cur_cell Γ) in Hdec.
+    rewrite !(eval_advice_next_cell Γ) in Hdec.
+    cbn [eval_cell Garden.Halo2.Synthesis.Cell.advice
+      Garden.Halo2.Synthesis.Cell.column Garden.Halo2.Synthesis.Cell.region
+      Garden.Halo2.Synthesis.Cell.row_offset] in Hdec.
+    replace (0 + 1) with 1 in Hdec by lia.
+    rewrite Hc_a, Hc_b, Hc_c, Hc_left, Hc_right, Hc_z1a, Hc_z1b, Hc_b1, Hc_b2,
+      Hconst_l in Hdec.
+    rewrite <- HcopyA, <- HcopyB, <- HcopyC in Hdec.
+    clear Hy Hgate_yq Hgate_dec Hc_a Hc_b Hc_c Hc_left Hc_right Hc_z1a Hc_z1b
+      Hc_b1 Hc_b2 Hconst_l HselD HselY HfixY HconstX HcopyA HcopyB HcopyC.
+    (* The canonicity-free core. *)
+    pose proof (merkle_hash_layer_fold Γ Selector.QSinsemilla1_1
+      Fixed.QSinsemilla2_1 Advice.A0 Advice.A1 Advice.A2 Advice.A3 Advice.A4
+      (Garden.Orchard.circuit.merkle_region i
+        RegionId.Merkle.Region.HashToPoint)
+      i
+      (UnOp.from (Γ.(Assignment.advice) Advice.A2
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A3
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB1) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB2) 0))
+      Hi Hload Hsel Hgate_sin
+      (fun row => generator_table_lookup_holds_1 Γ Hcircuit _ row)
+      Hq2_one Hq2_24 Hq2_26 Hq2_51 Hacc0 Hnondeg Hb1 Hb2 Hdec)
+      as Hcore.
+    destruct Hcore as (Hout & l & r & Hmsg & Hl & Hr).
+    split; [exact Hout |].
+    exists l, r.
+    split; [exact Hmsg |].
+    (* Cond-swap decode: the swapped pair against the [merkle_path_of]
+       reads. *)
+    pose proof (CondSwap.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+        Advice.A4
+        (enabled_nonzero Γ Selector.QCondSwap1 _ 0 HselNP) Hgate_cs) as Hcs.
+    pose proof (CondSwap.swap_is_bool Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap1 Advice.A0 Advice.A1 Advice.A2 Advice.A3
+        Advice.A4
+        (enabled_nonzero Γ Selector.QCondSwap1 _ 0 HselNP) Hgate_cs) as Hbool.
+    rewrite (cond_swap_output_if _ _ _ Hbool) in Hcs.
+    pose proof (f_equal CondSwap.a_swapped Hcs) as Hleft_sw.
+    pose proof (f_equal CondSwap.b_swapped Hcs) as Hright_sw.
+    with_strategy opaque [UnOp.from] cbn in Hleft_sw, Hright_sw.
+    cbn in Hcopy_node.
+    rewrite Hcopy_node in Hleft_sw, Hright_sw.
+    rewrite Hl, Hr.
+    setoid_rewrite Hleft_sw.
+    setoid_rewrite Hright_sw.
+    unfold read1, read4, read_advice, NP.
+    with_strategy opaque [UnOp.from] cbn.
+    destruct (UnOp.from (Γ.(Assignment.advice) Advice.A4
+      (Garden.Orchard.circuit.merkle_region i
+        RegionId.Merkle.Region.NodePosition) 0)
+      =? 1) eqn:Hbit.
+    - split; rewrite !FieldRewrite.from_from; reflexivity.
+    - split; rewrite !FieldRewrite.from_from; reflexivity.
+  Qed.
+  (** ** The per-layer statement, variant 2 (layers 16–31)
+
+      The variant-1 statement and proof with the second column bundle,
+      mirroring [OrchardActionMerkle.merkle_layer_correct_2]: the sibling
+      is read on [A6] and the position bit on [A9]. *)
+  Lemma merkle_layer_bot_2
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (i : Z) (Hi : 0 <= i < 32) (Hlt : (i <? 16) = false)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      (Hfacts : interpret_facts Γ (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node)))
+      (Hb : merkle_b_range_ok Γ)
+      (Hnondeg : SinsemillaHash.nondegenerate merkle_Q (merkle_words Γ i)) :
+    UnOp.from (eval_cell Γ (layouter_value
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node))) =
+      EccSpec.extract_x
+        (SinsemillaSpec.sinsemilla_hash_to_point merkle_Q
+          (merkle_words Γ i)) /\
+    exists l r : Z,
+      merkle_words Γ i = SinsemillaSpec.merkle_message i l r /\
+      UnOp.from l =
+        (if read9 Γ (NP i) =? 1
+         then read6 Γ (NP i)
+         else UnOp.from (eval_cell Γ node)) /\
+      UnOp.from r =
+        (if read9 Γ (NP i) =? 1
+         then UnOp.from (eval_cell Γ node)
+         else read6 Γ (NP i)).
+  Proof.
+    pose proof (holds_gates Γ Hcircuit) as Hgates.
+    pose proof (generator_table_facts Γ Hcircuit) as Hload.
+    destruct (Hb i Hi) as [Hb1 Hb2].
+    cbn [eval_cell Garden.Halo2.Synthesis.Cell.advice
+      Garden.Halo2.Synthesis.Cell.column Garden.Halo2.Synthesis.Cell.region
+      Garden.Halo2.Synthesis.Cell.row_offset] in Hb1, Hb2.
+    unfold Garden.Orchard.circuit.synthesize_merkle_layer in Hfacts |- *.
+    rewrite Hlt in Hfacts |- *.
+    unfold merkle_words, merkle_bits, merkle_q2, HTP in Hnondeg |- *.
+    rewrite Hlt in Hnondeg |- *.
+    (* Facts of the node-position region: selector and node copy. *)
+    pose proof Hfacts as Hnp.
+    apply interpret_layouter_facts_bind_left in Hnp.
+    unfold Garden.Orchard.circuit.synthesize_node_position_2,
+      Garden.Orchard.circuit.synthesize_node_position_instance in Hnp.
+    apply interpret_layouter_facts_in_namespace in Hnp.
+    apply interpret_layouter_facts_add_region in Hnp.
+    cbn [region_facts region_value Monad.bind Monad.ret
+      Garden.Halo2.Synthesis.RegionIsMonad List.app
+      interpret_facts interpret_fact] in Hnp.
+    destruct Hnp as (HselNP & Hcopy_node & _).
+    (* Facts of the hash layer: hash region and decomposition region. *)
+    pose proof Hfacts as Hh.
+    apply interpret_layouter_facts_bind_right in Hh.
+    unfold Garden.Orchard.circuit.synthesize_merkle_hash_layer_2 in Hh.
+    apply interpret_layouter_facts_in_namespace in Hh.
+    do 5 apply interpret_layouter_facts_bind_right in Hh.
+    pose proof Hh as Hhash.
+    apply interpret_layouter_facts_bind_left in Hhash.
+    apply interpret_layouter_facts_in_namespace in Hhash.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_to_point_2
+      in Hhash.
+    apply interpret_layouter_facts_add_region in Hhash.
+    pose proof Hh as Hdecf.
+    apply interpret_layouter_facts_bind_right,
+      interpret_layouter_facts_bind_left in Hdecf.
+    unfold Garden.Orchard.circuit.synthesize_merkle_decomposition_2,
+      Garden.Orchard.circuit.synthesize_merkle_decomposition_instance in Hdecf.
+    apply interpret_layouter_facts_add_region in Hdecf.
+    cbn [region_facts region_value layouter_value Monad.bind Monad.ret
+      Garden.Halo2.Synthesis.RegionIsMonad
+      Garden.Halo2.Synthesis.LayouterIsMonad
+      List.app interpret_facts interpret_fact] in Hdecf.
+    destruct Hdecf as (HselD & Hc_a & Hc_b & Hc_c & Hc_left & Hc_right &
+      Hc_z1a & Hc_z1b & Hc_b1 & Hc_b2 & Hconst_l & _).
+    cbn in Hc_a, Hc_b, Hc_c, Hc_left, Hc_right, Hc_z1a, Hc_z1b, Hc_b1, Hc_b2.
+    clear Hfacts Hh.
+    (* Hash-region facts: seed selector/fixed/constant, per-piece schedules
+       and piece copies. *)
+    pose proof Hhash as HselY.
+    apply interpret_region_facts_bind_left in HselY.
+    cbn [region_facts interpret_facts interpret_fact] in HselY.
+    destruct HselY as [HselY _].
+    pose proof Hhash as HfixY.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in HfixY.
+    cbn [region_facts interpret_facts interpret_fact] in HfixY.
+    destruct HfixY as [HfixY _].
+    pose proof Hhash as HconstX.
+    do 2 apply interpret_region_facts_bind_right in HconstX.
+    apply interpret_region_facts_bind_left in HconstX.
+    cbn [region_facts interpret_facts interpret_fact] in HconstX.
+    destruct HconstX as [HconstX _].
+    pose proof Hhash as HpieceA.
+    do 3 apply interpret_region_facts_bind_right in HpieceA.
+    apply interpret_region_facts_bind_left in HpieceA.
+    pose proof Hhash as HpieceB.
+    do 4 apply interpret_region_facts_bind_right in HpieceB.
+    apply interpret_region_facts_bind_left in HpieceB.
+    pose proof Hhash as HpieceC.
+    do 5 apply interpret_region_facts_bind_right in HpieceC.
+    apply interpret_region_facts_bind_left in HpieceC.
+    clear Hhash.
+    pose proof HpieceA as HselA.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselA.
+    apply interpret_region_facts_bind_left in HselA.
+    pose proof HpieceA as Hq2A.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2A.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2A.
+    pose proof HpieceA as HcopyA.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyA.
+    do 2 apply interpret_region_facts_bind_right in HcopyA.
+    apply interpret_region_facts_bind_left in HcopyA.
+    cbn in HcopyA.
+    destruct HcopyA as [HcopyA _].
+    pose proof HpieceB as HselB.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselB.
+    apply interpret_region_facts_bind_left in HselB.
+    pose proof HpieceB as Hq2B.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2B.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2B.
+    pose proof HpieceB as HcopyB.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyB.
+    do 2 apply interpret_region_facts_bind_right in HcopyB.
+    apply interpret_region_facts_bind_left in HcopyB.
+    cbn in HcopyB.
+    destruct HcopyB as [HcopyB _].
+    pose proof HpieceC as HselC.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HselC.
+    apply interpret_region_facts_bind_left in HselC.
+    pose proof HpieceC as Hq2C.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in Hq2C.
+    apply interpret_region_facts_bind_right,
+      interpret_region_facts_bind_left in Hq2C.
+    pose proof HpieceC as HcopyC.
+    unfold Garden.Halo2.halo2_gadgets.sinsemilla.chip.synthesize_hash_piece
+      in HcopyC.
+    do 2 apply interpret_region_facts_bind_right in HcopyC.
+    apply interpret_region_facts_bind_left in HcopyC.
+    cbn in HcopyC.
+    destruct HcopyC as [HcopyC _].
+    clear HpieceA HpieceB HpieceC.
+    (* Row schedules assembled across the three pieces. *)
+    assert (Hsel : forall j : nat, (j < 52)%nat ->
+        Γ ⊢ ⟦ Expression.Selector Selector.QSinsemilla1_2 ⟧
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.HashToPoint,
+            Z.of_nat j) = 1).
+    { intros j Hj.
+      apply SinsemillaHash.enabled_eq_one.
+      destruct (Nat.lt_ge_cases j 25) as [Hj25 | Hj25].
+      - pose proof (interpret_facts_In Γ _ _ HselA
+          (enable_selector_rows_fact _ Selector.QSinsemilla1_2 0 25 j Hj25))
+          as Hf.
+        cbn [interpret_fact] in Hf.
+        replace (Z.of_nat j) with (0 + Z.of_nat j) by lia.
+        exact Hf.
+      - destruct (Nat.lt_ge_cases j 27) as [Hj27 | Hj27].
+        + pose proof (interpret_facts_In Γ _ _ HselB
+            (enable_selector_rows_fact _ Selector.QSinsemilla1_2 25 2 (j - 25)
+              ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (25 + Z.of_nat (j - 25)) by lia.
+          exact Hf.
+        + pose proof (interpret_facts_In Γ _ _ HselC
+            (enable_selector_rows_fact _ Selector.QSinsemilla1_2 27 25 (j - 27)
+              ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (27 + Z.of_nat (j - 27)) by lia.
+          exact Hf. }
+    assert (Hq2_one : forall j : nat,
+        (j < 52)%nat -> j <> 24%nat -> j <> 26%nat -> j <> 51%nat ->
+        Γ.(Assignment.fixed) Fixed.QSinsemilla2_2
+          (Garden.Orchard.circuit.merkle_region i
+            RegionId.Merkle.Region.HashToPoint)
+          (Z.of_nat j) = 1).
+    { intros j Hj H24 H26 H51.
+      destruct (Nat.lt_ge_cases j 25) as [Hj25 | Hj25].
+      - pose proof (interpret_facts_In Γ _ _ Hq2A
+          (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_2 0 25 j false
+            ltac:(lia))) as Hf.
+        cbn [interpret_fact] in Hf.
+        replace (Z.of_nat j) with (0 + Z.of_nat j) by lia.
+        exact Hf.
+      - destruct (Nat.lt_ge_cases j 27) as [Hj27 | Hj27].
+        + pose proof (interpret_facts_In Γ _ _ Hq2B
+            (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_2 25 2 (j - 25)
+              false ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (25 + Z.of_nat (j - 25)) by lia.
+          exact Hf.
+        + pose proof (interpret_facts_In Γ _ _ Hq2C
+            (assign_q_s2_rows_fact_step _ Fixed.QSinsemilla2_2 27 25 (j - 27)
+              true ltac:(lia))) as Hf.
+          cbn [interpret_fact] in Hf.
+          replace (Z.of_nat j) with (27 + Z.of_nat (j - 27)) by lia.
+          exact Hf. }
+    assert (Hq2_24 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_2
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        24 = 0).
+    { pose proof (interpret_facts_In Γ _ _ Hq2A
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_2 0 25 false
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (0 + Z.of_nat (25 - 1)) with 24 in Hf by lia.
+      exact Hf. }
+    assert (Hq2_26 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_2
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        26 = 0).
+    { pose proof (interpret_facts_In Γ _ _ Hq2B
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_2 25 2 false
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (25 + Z.of_nat (2 - 1)) with 26 in Hf by lia.
+      exact Hf. }
+    assert (Hq2_51 : Γ.(Assignment.fixed) Fixed.QSinsemilla2_2
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        51 = 2).
+    { pose proof (interpret_facts_In Γ _ _ Hq2C
+        (assign_q_s2_rows_fact_last _ Fixed.QSinsemilla2_2 27 25 true
+          ltac:(lia))) as Hf.
+      cbn [interpret_fact] in Hf.
+      replace (27 + Z.of_nat (25 - 1)) with 51 in Hf by lia.
+      exact Hf. }
+    clear HselA HselB HselC Hq2A Hq2B Hq2C.
+    (* The four gates of the layer, from [satisfies_gates]. *)
+    assert (Hgate_sin : forall row : Z,
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_gate
+          Selector.QSinsemilla1_2 Fixed.QSinsemilla2_2
+          Advice.A5 Advice.A6 Advice.A8 Advice.A9 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint,
+          row)).
+    { intros row.
+      apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.chip.sinsemilla_gate
+          Selector.QSinsemilla1_2 Fixed.QSinsemilla2_2
+          Advice.A5 Advice.A6 Advice.A8 Advice.A9)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_yq :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.chip.initial_y_q_gate
+          Selector.QSinsemilla4_2 Fixed.LagrangeCoeffs1
+          Advice.A5 Advice.A6 Advice.A8 Advice.A9 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.chip.initial_y_q_gate
+          Selector.QSinsemilla4_2 Fixed.LagrangeCoeffs1
+          Advice.A5 Advice.A6 Advice.A8 Advice.A9)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_cs :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+          Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+          Advice.A9 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.utilities.cond_swap.cond_swap_gate
+          Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+          Advice.A9)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    assert (Hgate_dec :
+        Γ ⊢ ⟦ Garden.Halo2.halo2_gadgets.sinsemilla.merkle.chip
+            .decomposition_check_gate
+          Selector.QMerkleDecompose2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+          Advice.A9 ⟧
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition,
+          0)).
+    { apply (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.sinsemilla.merkle.chip
+          .decomposition_check_gate
+          Selector.QMerkleDecompose2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+          Advice.A9)
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition)
+        0
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        Hgates). }
+    (* Seed: the accumulator at row 0 is the domain point. *)
+    pose proof (InitialYQ.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.HashToPoint)
+        0 Selector.QSinsemilla4_2 Fixed.LagrangeCoeffs1
+        Advice.A5 Advice.A6 Advice.A8 Advice.A9
+        (enabled_nonzero Γ Selector.QSinsemilla4_2 _ 0 HselY) Hgate_yq) as Hy.
+    rewrite (fixed_expression_eq Γ Fixed.LagrangeCoeffs1 _ 0
+      Garden.Orchard.circuit.merkle_q_y HfixY) in Hy.
+    pose proof (SinsemillaHash.acc_at_init Γ Advice.A5 Advice.A6 Advice.A8
+      Advice.A9 _ 0 (UnOp.from Garden.Orchard.circuit.merkle_q_y) Hy) as Hacc0.
+    rewrite (eval_advice_cur_cell Γ _ Advice.A5 0) in Hacc0.
+    rewrite HconstX in Hacc0.
+    rewrite merkle_q_x_reduced in Hacc0.
+    rewrite FieldRewrite.from_from in Hacc0.
+    rewrite merkle_q_y_reduced in Hacc0.
+    (* The decomposition-gate record, routed through the copies to the hash
+       region's running-sum cells and the range/swap cells. *)
+    pose proof (DecompositionCheck.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.Decomposition)
+        0 Selector.QMerkleDecompose2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+        Advice.A9
+        (enabled_nonzero Γ Selector.QMerkleDecompose2 _ 0 HselD) Hgate_dec)
+      as Hdec.
+    cbn in Hconst_l.
+    rewrite !(eval_advice_cur_cell Γ) in Hdec.
+    rewrite !(eval_advice_next_cell Γ) in Hdec.
+    cbn [eval_cell Garden.Halo2.Synthesis.Cell.advice
+      Garden.Halo2.Synthesis.Cell.column Garden.Halo2.Synthesis.Cell.region
+      Garden.Halo2.Synthesis.Cell.row_offset] in Hdec.
+    replace (0 + 1) with 1 in Hdec by lia.
+    rewrite Hc_a, Hc_b, Hc_c, Hc_left, Hc_right, Hc_z1a, Hc_z1b, Hc_b1, Hc_b2,
+      Hconst_l in Hdec.
+    rewrite <- HcopyA, <- HcopyB, <- HcopyC in Hdec.
+    clear Hy Hgate_yq Hgate_dec Hc_a Hc_b Hc_c Hc_left Hc_right Hc_z1a Hc_z1b
+      Hc_b1 Hc_b2 Hconst_l HselD HselY HfixY HconstX HcopyA HcopyB HcopyC.
+    (* The canonicity-free core. *)
+    pose proof (merkle_hash_layer_fold Γ Selector.QSinsemilla1_2
+      Fixed.QSinsemilla2_2 Advice.A5 Advice.A6 Advice.A7 Advice.A8 Advice.A9
+      (Garden.Orchard.circuit.merkle_region i
+        RegionId.Merkle.Region.HashToPoint)
+      i
+      (UnOp.from (Γ.(Assignment.advice) Advice.A7
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A8
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB1) 0))
+      (UnOp.from (Γ.(Assignment.advice) Advice.A9
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.RangeB2) 0))
+      Hi Hload Hsel Hgate_sin
+      (fun row => generator_table_lookup_holds_2 Γ Hcircuit _ row)
+      Hq2_one Hq2_24 Hq2_26 Hq2_51 Hacc0 Hnondeg Hb1 Hb2 Hdec)
+      as Hcore.
+    destruct Hcore as (Hout & l & r & Hmsg & Hl & Hr).
+    split; [exact Hout |].
+    exists l, r.
+    split; [exact Hmsg |].
+    (* Cond-swap decode: the swapped pair against the [merkle_path_of]
+       reads. *)
+    pose proof (CondSwap.deterministic Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+        Advice.A9
+        (enabled_nonzero Γ Selector.QCondSwap2 _ 0 HselNP) Hgate_cs) as Hcs.
+    pose proof (CondSwap.swap_is_bool Γ
+        (Garden.Orchard.circuit.merkle_region i
+          RegionId.Merkle.Region.NodePosition)
+        0 Selector.QCondSwap2 Advice.A5 Advice.A6 Advice.A7 Advice.A8
+        Advice.A9
+        (enabled_nonzero Γ Selector.QCondSwap2 _ 0 HselNP) Hgate_cs) as Hbool.
+    rewrite (cond_swap_output_if _ _ _ Hbool) in Hcs.
+    pose proof (f_equal CondSwap.a_swapped Hcs) as Hleft_sw.
+    pose proof (f_equal CondSwap.b_swapped Hcs) as Hright_sw.
+    with_strategy opaque [UnOp.from] cbn in Hleft_sw, Hright_sw.
+    cbn in Hcopy_node.
+    rewrite Hcopy_node in Hleft_sw, Hright_sw.
+    rewrite Hl, Hr.
+    setoid_rewrite Hleft_sw.
+    setoid_rewrite Hright_sw.
+    unfold read6, read9, read_advice, NP.
+    with_strategy opaque [UnOp.from] cbn.
+    destruct (UnOp.from (Γ.(Assignment.advice) Advice.A9
+      (Garden.Orchard.circuit.merkle_region i
+        RegionId.Merkle.Region.NodePosition) 0)
+      =? 1) eqn:Hbit.
+    - split; rewrite !FieldRewrite.from_from; reflexivity.
+    - split; rewrite !FieldRewrite.from_from; reflexivity.
+  Qed.
+  (** The per-layer statement, dispatched across the two column variants
+      and reconciled with the layer-dependent authentication-path reads
+      of [OrchardAdversarialApi] (sibling on A1/A6, position bit on
+      A4/A9). *)
+  Lemma merkle_layer_bot
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (i : Z) (Hi : 0 <= i < 32)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      (Hfacts : interpret_facts Γ (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node)))
+      (Hb : merkle_b_range_ok Γ)
+      (Hnondeg : SinsemillaHash.nondegenerate merkle_Q (merkle_words Γ i)) :
+    UnOp.from (eval_cell Γ (layouter_value
+        (Garden.Orchard.circuit.synthesize_merkle_layer i node))) =
+      EccSpec.extract_x
+        (SinsemillaSpec.sinsemilla_hash_to_point merkle_Q
+          (merkle_words Γ i)) /\
+    exists l r : Z,
+      merkle_words Γ i = SinsemillaSpec.merkle_message i l r /\
+      UnOp.from l =
+        (if merkle_swap_at Γ i
+         then merkle_sibling_at Γ i
+         else UnOp.from (eval_cell Γ node)) /\
+      UnOp.from r =
+        (if merkle_swap_at Γ i
+         then UnOp.from (eval_cell Γ node)
+         else merkle_sibling_at Γ i).
+  Proof.
+    unfold merkle_swap_at, merkle_swap_cell, merkle_sibling_at,
+      merkle_node_position.
+    destruct (i <? 16) eqn:Hlt.
+    - exact (merkle_layer_bot_1 Γ Hcircuit i Hi Hlt node Hfacts Hb Hnondeg).
+    - exact (merkle_layer_bot_2 Γ Hcircuit i Hi Hlt node Hfacts Hb Hnondeg).
+  Qed.
+
+  (** ** The running node cell along the synthesized path
+
+      [circuit.synthesize_merkle_layers] threads the node cell forward
+      from the leaf, incrementing the layer index; [iter_from] is that
+      iteration over an abstract step, so the fixpoint body never mentions
+      a synthesis constant. *)
+
+  Fixpoint iter_from {A : Type} (step : Z -> A -> A) (layer : Z) (x : A)
+      (k : nat) : A :=
+    match k with
+    | O => x
+    | S m => iter_from step (layer + 1) (step layer x) m
+    end.
+
+  Definition merkle_step (layer : Z)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t)
+      : Garden.Halo2.Synthesis.Cell.t columns RegionId.t :=
+    layouter_value (Garden.Orchard.circuit.synthesize_merkle_layer layer node).
+
+  Definition node_from (layer : Z)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t) (k : nat)
+      : Garden.Halo2.Synthesis.Cell.t columns RegionId.t :=
+    iter_from merkle_step layer node k.
+
+  Lemma iter_from_S {A : Type} (step : Z -> A -> A) (k : nat) :
+    forall (layer : Z) (x : A),
+      iter_from step layer x (S k) =
+        step (layer + Z.of_nat k) (iter_from step layer x k).
+  Proof.
+    induction k as [| k IH]; intros layer x.
+    - replace (layer + Z.of_nat 0) with layer by lia.
+      reflexivity.
+    - assert (E1 : iter_from step layer x (S (S k)) =
+        iter_from step (layer + 1) (step layer x) (S k)) by reflexivity.
+      assert (E2 : iter_from step layer x (S k) =
+        iter_from step (layer + 1) (step layer x) k) by reflexivity.
+      rewrite E1, E2, (IH (layer + 1) (step layer x)).
+      replace (layer + Z.of_nat (S k)) with (layer + 1 + Z.of_nat k) by lia.
+      reflexivity.
+  Qed.
+
+  (** The [adversarial_api] node chain is the same iteration started at the
+      leaf cell. *)
+  Lemma merkle_node_cell_eq (k : nat) :
+    merkle_node_cell k = node_from 0 cm_old_x_cell k.
+  Proof.
+    unfold node_from.
+    induction k as [| k IH].
+    - reflexivity.
+    - rewrite iter_from_S.
+      change (0 + Z.of_nat k) with (Z.of_nat k).
+      rewrite <- IH.
+      reflexivity.
+  Qed.
+
+  Lemma layers_value :
+    forall (n : nat) (layer : Z)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t),
+      layouter_value
+        (Garden.Orchard.circuit.synthesize_merkle_layers n layer node) =
+        node_from layer node n.
+  Proof.
+    unfold node_from.
+    induction n as [| n IH]; intros layer node.
+    - reflexivity.
+    - cbn [Garden.Orchard.circuit.synthesize_merkle_layers Monad.bind
+        Garden.Halo2.Synthesis.LayouterIsMonad layouter_value].
+      rewrite (IH (layer + 1)).
+      reflexivity.
+  Qed.
+
+  (** Every layer of a synthesized run of [n] layers carries its own
+      layouter facts, at its own index and running node cell. *)
+  Lemma layers_facts (Γ : Assignment.t columns RegionId.t) :
+    forall (n : nat) (layer : Z)
+      (node : Garden.Halo2.Synthesis.Cell.t columns RegionId.t),
+      interpret_facts Γ (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_layers n layer node)) ->
+      forall k : nat, (k < n)%nat ->
+        interpret_facts Γ (layouter_facts
+          (Garden.Orchard.circuit.synthesize_merkle_layer
+            (layer + Z.of_nat k) (node_from layer node k))).
+  Proof.
+    induction n as [| n IH]; intros layer node Hfacts k Hk; [lia |].
+    cbn [Garden.Orchard.circuit.synthesize_merkle_layers Monad.bind
+      Garden.Halo2.Synthesis.LayouterIsMonad] in Hfacts.
+    destruct k as [| k].
+    - apply interpret_layouter_facts_bind_left in Hfacts.
+      replace (layer + Z.of_nat 0) with layer by lia.
+      exact Hfacts.
+    - apply interpret_layouter_facts_bind_right in Hfacts.
+      cbv beta in Hfacts.
+      pose proof (IH (layer + 1) (merkle_step layer node) Hfacts k
+        ltac:(lia)) as Hstep.
+      replace (layer + Z.of_nat (S k)) with (layer + 1 + Z.of_nat k) by lia.
+      exact Hstep.
+  Qed.
+
+  (** ** The §4.9 escape is decidable at the 32 layers
+
+      A layer's fold is undefined or it is not; no classical reasoning is
+      needed to split the clause, since the disjunct is an equation
+      between options. *)
+  Lemma layer_bot_dec (Γ : Assignment.t columns RegionId.t) (n : nat) :
+    (exists i : nat, (i < n)%nat /\
+       sinsemilla_hash_to_point_bot merkle_Q
+         (merkle_words Γ (Z.of_nat i)) = None) \/
+    (forall i : nat, (i < n)%nat ->
+       sinsemilla_hash_to_point_bot merkle_Q
+         (merkle_words Γ (Z.of_nat i)) <> None).
+  Proof.
+    induction n as [| n IH].
+    - right. intros i Hi. lia.
+    - destruct IH as [Hex | Hall].
+      + left.
+        destruct Hex as (i & Hi & Hnone).
+        exists i.
+        split; [lia | exact Hnone].
+      + destruct (sinsemilla_hash_to_point_bot merkle_Q
+          (merkle_words Γ (Z.of_nat n))) as [P |] eqn:E.
+        * right.
+          intros i Hi.
+          destruct (Nat.eq_dec i n) as [-> | Hne].
+          -- rewrite E. discriminate.
+          -- apply Hall. lia.
+        * left.
+          exists n.
+          split; [lia | exact E].
+  Qed.
+
+  (** ** The clause
+
+      From acceptance and the two 5-bit lookup ranges alone.  No layer's
+      nondegeneracy and no 255-bit canonicity is assumed: an exceptional
+      layer lands in disjunct 2 (§4.9), and a non-canonical decomposition
+      is absorbed by the witnessed message pair of
+      [OrchardAdversarialApi.anchor_path_tracks] (§4.18.4's note on
+      non-canonical layer inputs). *)
+  Theorem anchor_obligation_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hb : merkle_b_range_ok Γ) :
+    anchor_obligation Γ.
+  Proof.
+    unfold anchor_obligation.
+    destruct (Z.eq_dec (OrchardSpec.in_v_old (read_action_inputs Γ)) 0)
+      as [Hv0 | Hvold]; [left; exact Hv0 |].
+    destruct (layer_bot_dec Γ 32) as [Hex | Hall];
+      [right; left; exact Hex |].
+    right; right.
+    (* Every layer's fold is defined, hence nondegenerate. *)
+    assert (Hnd : forall i : nat, (i < 32)%nat ->
+        SinsemillaHash.nondegenerate merkle_Q (merkle_words Γ (Z.of_nat i)))
+      by (intros i Hi;
+          exact (proj1 (hash_to_point_bot_iff merkle_Q _) (Hall i Hi))).
+    (* The path's layouter facts, per layer. *)
+    pose proof (merkle_path_facts Γ Hcircuit) as Hpath.
+    change (interpret_facts Γ
+      (layouter_facts
+        (Garden.Orchard.circuit.synthesize_merkle_path cm_old_x_cell)))
+      in Hpath.
+    unfold Garden.Orchard.circuit.synthesize_merkle_path in Hpath.
+    apply interpret_layouter_facts_in_namespace in Hpath.
+    assert (Hlayer : forall i : nat, (i < 32)%nat ->
+        interpret_facts Γ (layouter_facts
+          (Garden.Orchard.circuit.synthesize_merkle_layer
+            (Z.of_nat i) (merkle_node_cell i)))).
+    { intros i Hi.
+      pose proof (layers_facts Γ 32%nat 0 cm_old_x_cell Hpath i Hi) as Hf.
+      change (0 + Z.of_nat i) with (Z.of_nat i) in Hf.
+      rewrite (merkle_node_cell_eq i).
+      exact Hf. }
+    (* The per-layer conclusions. *)
+    assert (Hstep : forall i : nat, (i < 32)%nat ->
+        UnOp.from (eval_cell Γ (merkle_node_cell (S i))) =
+          EccSpec.extract_x
+            (SinsemillaSpec.sinsemilla_hash_to_point merkle_Q
+              (merkle_words Γ (Z.of_nat i))) /\
+        (exists l r : Z,
+          merkle_words Γ (Z.of_nat i) =
+            SinsemillaSpec.merkle_message (Z.of_nat i) l r /\
+          UnOp.from l =
+            (if merkle_swap_at Γ (Z.of_nat i)
+             then merkle_sibling_at Γ (Z.of_nat i)
+             else UnOp.from (eval_cell Γ (merkle_node_cell i))) /\
+          UnOp.from r =
+            (if merkle_swap_at Γ (Z.of_nat i)
+             then UnOp.from (eval_cell Γ (merkle_node_cell i))
+             else merkle_sibling_at Γ (Z.of_nat i)))).
+    { intros i Hi.
+      exact (merkle_layer_bot Γ Hcircuit (Z.of_nat i) ltac:(lia)
+        (merkle_node_cell i) (Hlayer i Hi) Hb (Hnd i Hi)). }
+    repeat apply conj.
+    - (* Each layer's output node is the ⊥-carrying hash of its message. *)
+      intros i Hi.
+      rewrite (sinsemilla_hash_bot_some merkle_Q _ (Hnd i Hi)).
+      unfold merkle_node_at, SinsemillaSpec.sinsemilla_hash.
+      f_equal.
+      exact (proj1 (Hstep i Hi)).
+    - (* Each layer hashes a [merkle_message] of a witnessed pair. *)
+      intros i Hi.
+      exact (proj2 (Hstep i Hi)).
+    - (* The leaf: the path starts at the witnessed old-note commitment. *)
+      reflexivity.
+    - (* The root: the anchor row, on the active branch. *)
+      unfold merkle_node_at.
+      rewrite (merkle_node_cell_eq 32%nat).
+      rewrite <- (layers_value 32%nat 0 cm_old_x_cell).
+      symmetry.
+      exact (OrchardActionBridges.anchor_instance_eq_merkle_root_when_active
+        Γ Hcircuit Hvold).
+  Qed.
+
+  (** The clause at the operational level: replay success and ideal
+      acceptance of the serialized circuit discharge both premises — the
+      relational [Holds] through [orchard_operational_sound], the two
+      5-bit ranges through the [ShortSite] certificates. *)
+  Corollary anchor_obligation_operational
+      (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+      (Hreplay :
+        apply_events orchard_events (initial_grid advice instance_) =
+          Some grid)
+      (Hmock :
+        mock_prover_accepts orchard_indexed_system orchard_events grid
+          orchard_table_rows) :
+    anchor_obligation (realize Index.indices region_start_of grid).
+  Proof.
+    exact (anchor_obligation_of_holds
+      (realize Index.indices region_start_of grid)
+      (orchard_operational_sound advice instance_ grid Hreplay Hmock)
+      (merkle_b_range_ok_operational advice instance_ grid Hreplay Hmock)).
+  Qed.
+
+  (** ** The collision-resistance reading of the witnessed pair
+
+      Statement only: no proof is attempted, and none is possible from
+      the circuit alone — the wrapped decomposition is exactly the slack
+      §4.18.4 grants ("each layer does not check that its input bit
+      sequence is a canonical encoding …").  What a cryptographic
+      assumption buys is stated here in the style of the balance proof's
+      discrete-logarithm reduction: under Theorem 5.4.3
+      ([OrchardAdversarialApi.SinsemillaCollisionReduction]), an accepted
+      assignment either decomposes canonically at every layer — in which
+      case [anchor_path_tracks] collapses to
+      [OrchardActionMerkle.merkle_root_cell_correct]'s conclusion, the
+      total §4.9 path validity — or exhibits a nontrivial discrete
+      logarithm relation among the Merkle domain point and the Sinsemilla
+      generators.
+
+      Two caveats belong with the statement, since it is stated and not
+      proved.  First, the reduction has content only against a second
+      accepted assignment (or a second message) that hashes to the same
+      value: a single wrapped witness exhibits no collision by itself, so
+      the honest single-assignment reading of the §4.9 escape is the
+      exceptional-case one
+      ([OrchardAdversarialApi.anchor_exceptional_or_dlog_claim], Theorem
+      5.4.4), which this file's [anchor_obligation] already carries as its
+      second disjunct.  Second, recovering the canonical pair from a
+      collision additionally needs the injectivity of
+      [SinsemillaSpec.merkle_message] on the bounded pairs, which the
+      decomposition gate provides but [anchor_path_tracks]' existential
+      does not record. *)
+  Definition anchor_canonical_or_dlog_claim : Prop :=
+    SinsemillaCollisionReduction ->
+    forall (Γ : Assignment.t columns RegionId.t),
+      Holds Γ ->
+      merkle_b_range_ok Γ ->
+      (forall i : Z, 0 <= i < 32 -> merkle_layer_canonical Γ i) \/
+      (exists (c0 : Z) (cs : list (Z * Z)),
+         sinsemilla_dlog_relation merkle_Q c0 cs).
+End OrchardMerkleBot.

--- a/Garden/Orchard/circuit_proof/note_commit_bot.v
+++ b/Garden/Orchard/circuit_proof/note_commit_bot.v
@@ -1,0 +1,410 @@
+(** * The two note-commitment ⊥ clauses of §4.18.4, from acceptance alone
+
+    §4.18.4 'Action Statement (Orchard)' of the Zcash protocol specification
+    ([docs/protocol.pdf]) states the two note-commitment clauses
+    disjunctively:
+
+    - 'New note commitment integrity':
+      [Extract⊥_P(NoteCommit^Orchard_rcm_new(g⋆_d_new, pk⋆_d_new, v_new,
+      ρ_new, ψ_new)) ∈ {cm_x, ⊥}] with [ρ_new = nf_old];
+    - 'Old note commitment integrity':
+      [NoteCommit^Orchard_rcm_old(g⋆_d_old, pk⋆_d_old, v_old, ρ_old, ψ_old)
+      ∈ {cm^old, ⊥}].
+
+    The ⊥ member is not slack the model invents: §5.4.1.9 'Sinsemilla Hash
+    Function' defines [SinsemillaHashToPoint] through the partial
+    incomplete addition [⊞], whose exceptional operand pairs
+    ([(x, y) ⊞ (x′, y′) = ⊥ if x = x′]) the circuit's gates leave
+    unconstrained, and the §4.18.4 non-normative note says so: "If
+    NoteCommit^Orchard returns ⊥ for the old or new note, then the
+    corresponding note commitment integrity check is satisfied.  This
+    models the fact that the implemented circuit uses incomplete point
+    addition to compute SinsemillaHashToPoint."
+
+    This file discharges both clauses in the ⊥-carrying form of
+    [circuit_proof/adversarial_api.v] — [cmx_obligation] and
+    [old_note_obligation] — from circuit acceptance and the short-lookup
+    range families alone.  No nondegeneracy and no canonicity hypothesis
+    appears.
+
+    Proof shape.  The ⊥-carrying fold of [circuit_proof/protocol_spec_bot.v]
+    is [None] exactly when the total fold's incomplete additions meet an
+    exceptional pair ([hash_to_point_bot_iff] — the bot fold tracks the
+    total fold until the first exceptional step, at which point it is
+    [None] and stays [None]).  So each clause is a case split on that fold
+    over the *witnessed* message: on [None] the ⊥ disjunct closes
+    definitionally through the [option_map] commitment shells; otherwise
+    the equivalence hands the existing nondegeneracy-conditioned theorem
+    ([NoteCommitNewCmx.cmx_correct],
+    [OrchardValidActionInputs.old_note_commit_integrity]) exactly the
+    hypothesis it wants, and the honest branch is reused verbatim.  The
+    only new content is the transport of the fold's word list between the
+    circuit spelling (the hash region's grid words) and the protocol
+    spelling ([OrchardSpec.note_commit_message] of the read inputs), which
+    the words-canonicity theorems already provide.
+
+    Anti-blowup discipline ([docs/compile-performance.md]): every bridge is
+    stated over variable inputs or composed as a term
+    ([eq_trans]/[eq_sym]/[f_equal]), so no unification ever compares two
+    sides differing underneath a [sinsemilla_hash_to_point] application. *)
+
+Require Import Stdlib.ZArith.ZArith.
+Require Import Stdlib.Lists.List.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.internal_spec.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.protocol_equiv.
+Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
+Require Import Garden.Orchard.circuit_proof.note_commit.hash.
+Require Import Garden.Orchard.circuit_proof.note_commit.words.
+Require Import Garden.Orchard.circuit_proof.note_commit.cmx.
+Require Import Garden.Orchard.circuit_proof.old_note.words.
+Require Import Garden.Orchard.circuit_proof.old_note.open.
+Require Import Garden.Orchard.circuit_proof.nullifier_k.out.
+Require Import Garden.Orchard.circuit_proof.us_free.nullifier_k.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial_api.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardNoteCommitBot.
+  Import OrchardActionInputs.
+  Import OrchardProtocolSpecBot.
+  Import OrchardAdversarialApi.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** ** The protocol-layer reading of the circuit-structured action spec
+
+      [OrchardAction.satisfies_specification] composes the per-output
+      bridges with the witness elimination and the protocol equivalence
+      inside one theorem; the two clauses here need the same composition
+      but only two of its fields, and without the Merkle side condition
+      that theorem carries.  The composition is stated once, at the record
+      level, and projected. *)
+
+  Lemma action_spec_protocol
+      (Γ : Assignment.t columns RegionId.t) (Hcircuit : Holds Γ) :
+    action_spec_of Γ =
+    OrchardProtocolSpec.orchard_action_spec orchard_circuit_params
+      (read_action_inputs Γ).
+  Proof.
+    exact (eq_trans
+      (OrchardActionUsFreeNullifierK.action_spec_us_free Γ Hcircuit)
+      (OrchardProtocolEquiv.output_protocol_eq (read_action_inputs Γ)
+        (OrchardValidActionInputs.protocol_typed_inputs_of_holds
+          Γ Hcircuit))).
+  Qed.
+
+  (** Record projections of the protocol action spec, over VARIABLE
+      parameters and inputs: both sides are the same application, so
+      neither the Sinsemilla fold nor the nullifier is ever reduced. *)
+
+  Lemma out_nf_old_of_action_spec
+      (prm : OrchardSpec.Params) (inp : OrchardSpec.ActionInputs) :
+    OrchardSpec.out_nf_old
+      (OrchardProtocolSpec.orchard_action_spec prm inp) =
+    OrchardProtocolSpec.nullifier
+      (OrchardSpec.in_nk inp) (OrchardSpec.in_rho_old inp)
+      (OrchardSpec.in_psi_old inp) (OrchardSpec.in_cm_old inp).
+  Proof. reflexivity. Qed.
+
+  Lemma out_cmx_of_action_spec
+      (prm : OrchardSpec.Params) (inp : OrchardSpec.ActionInputs) :
+    OrchardSpec.out_cmx
+      (OrchardProtocolSpec.orchard_action_spec prm inp) =
+    OrchardProtocolSpec.OrchardCmx prm
+      (OrchardSpec.in_g_d_new inp) (OrchardSpec.in_pk_d_new inp)
+      (OrchardSpec.in_v_new inp)
+      (OrchardProtocolSpec.nullifier
+        (OrchardSpec.in_nk inp) (OrchardSpec.in_rho_old inp)
+        (OrchardSpec.in_psi_old inp) (OrchardSpec.in_cm_old inp))
+      (OrchardSpec.in_psi_new inp) (OrchardSpec.in_rcm_new inp).
+  Proof. reflexivity. Qed.
+
+  (** ** The new-note lane
+
+      The hashed message of the [Which.New] hash-to-point region, in the
+      protocol spelling: the ρ_new argument is the (total, ⊥-free)
+      nullifier of the old-note inputs, which is what makes the whole
+      commitment a function of [read_action_inputs] alone. *)
+
+  Local Notation new_msg Γ :=
+    (OrchardSpec.note_commit_message
+      (OrchardSpec.in_g_d_new (read_action_inputs Γ))
+      (OrchardSpec.in_pk_d_new (read_action_inputs Γ))
+      (OrchardSpec.in_v_new (read_action_inputs Γ))
+      (OrchardProtocolSpec.nullifier
+        (OrchardSpec.in_nk (read_action_inputs Γ))
+        (OrchardSpec.in_rho_old (read_action_inputs Γ))
+        (OrchardSpec.in_psi_old (read_action_inputs Γ))
+        (OrchardSpec.in_cm_old (read_action_inputs Γ)))
+      (OrchardSpec.in_psi_new (read_action_inputs Γ))).
+
+  (** Reader read-offs of the new-note fields (record-literal projections),
+      named so the word identification closes on syntactically identical
+      terms. *)
+
+  Lemma in_g_d_new_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.in_g_d_new (read_action_inputs Γ) =
+    read_point Γ RegionId.NoteCommitNewWitnessGD.
+  Proof. reflexivity. Qed.
+
+  Lemma in_pk_d_new_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.in_pk_d_new (read_action_inputs Γ) =
+    read_point Γ RegionId.NoteCommitNewWitnessPkD.
+  Proof. reflexivity. Qed.
+
+  Lemma in_v_new_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.in_v_new (read_action_inputs Γ) =
+    read Γ (RegionId.WitnessInput RegionId.WitnessInput.VNew).
+  Proof. reflexivity. Qed.
+
+  Lemma in_psi_new_read (Γ : Assignment.t columns RegionId.t) :
+    OrchardSpec.in_psi_new (read_action_inputs Γ) =
+    read Γ RegionId.NoteCommitNewWitnessPsi.
+  Proof. reflexivity. Qed.
+
+  (** The 109 grid words of the [Which.New] hash-to-point region are the
+      protocol's note-commitment message of the read inputs: the word
+      identification ([NoteCommitNewWords.note_commit_new_words_correct],
+      from acceptance and the short lookups) with the witnessed ρ_new cell
+      resolved to the protocol nullifier ([NullifierKOut.nullifier_cell_correct]
+      through the record-level composition). *)
+  Lemma new_words_protocol
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ) :
+    NoteCommitNewHash.note_commit_new_words Γ = new_msg Γ.
+  Proof.
+    pose proof
+      (NoteCommitNewWords.note_commit_new_words_correct Γ Hcircuit Hshort)
+      as Hw.
+    cbv zeta in Hw.
+    pose proof (NullifierKOut.nullifier_cell_correct Γ Hcircuit) as Hnf.
+    cbv zeta in Hnf.
+    rewrite (action_spec_protocol Γ Hcircuit) in Hnf.
+    rewrite
+      (out_nf_old_of_action_spec orchard_circuit_params (read_action_inputs Γ))
+      in Hnf.
+    rewrite Hnf in Hw.
+    rewrite (in_g_d_new_read Γ), (in_pk_d_new_read Γ), (in_v_new_read Γ),
+      (in_psi_new_read Γ).
+    exact Hw.
+  Qed.
+
+  (** The nondegeneracy of the ⊥-carrying fold over the protocol message is
+      the nondegeneracy the [Which.New] hash theorem asks for. *)
+  Lemma new_nondegenerate_transport
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ)
+      (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.note_commit_q orchard_circuit_params) (new_msg Γ)) :
+    SinsemillaHash.nondegenerate NoteCommitNewHash.note_commit_Q
+      (NoteCommitNewHash.note_commit_new_words Γ).
+  Proof.
+    rewrite NoteCommitNewHash.note_commit_Q_eq.
+    rewrite (new_words_protocol Γ Hcircuit Hshort).
+    exact Hnd.
+  Qed.
+
+  (** The tracking branch of 'New note commitment integrity': where the
+      ⊥-carrying fold is defined, the protocol's new-note commitment
+      x-coordinate is the public [CMX] row. *)
+  (* The two record steps below are taken by [rewrite] inside the
+     hypothesis, not by an [f_equal] on the projection:
+     [OrchardSpec.out_cmx] is a primitive projection, so
+     [f_equal OrchardSpec.out_cmx Hspec] hands unification a [Proj] node
+     against a projection application and it falls back to normalizing the
+     shared [orchard_action_spec] argument — the 109-step Sinsemilla fold
+     ([docs/compile-performance.md], "Never normalize Poseidon round
+     chains" / "Never hand unification sides that differ under a big
+     fold").  Rewriting leaves the fold untouched. *)
+  Lemma cmx_spec_value
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ)
+      (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.note_commit_q orchard_circuit_params) (new_msg Γ)) :
+    OrchardProtocolSpec.OrchardCmx orchard_circuit_params
+      (OrchardSpec.in_g_d_new (read_action_inputs Γ))
+      (OrchardSpec.in_pk_d_new (read_action_inputs Γ))
+      (OrchardSpec.in_v_new (read_action_inputs Γ))
+      (OrchardProtocolSpec.nullifier
+        (OrchardSpec.in_nk (read_action_inputs Γ))
+        (OrchardSpec.in_rho_old (read_action_inputs Γ))
+        (OrchardSpec.in_psi_old (read_action_inputs Γ))
+        (OrchardSpec.in_cm_old (read_action_inputs Γ)))
+      (OrchardSpec.in_psi_new (read_action_inputs Γ))
+      (OrchardSpec.in_rcm_new (read_action_inputs Γ)) =
+    read_public_instance Γ Garden.Orchard.circuit.CMX.
+  Proof.
+    pose proof (NoteCommitNewCmx.cmx_correct Γ Hcircuit
+      (new_nondegenerate_transport Γ Hcircuit Hshort Hnd) Hshort) as Hcmx.
+    rewrite (action_spec_protocol Γ Hcircuit) in Hcmx.
+    rewrite
+      (out_cmx_of_action_spec orchard_circuit_params (read_action_inputs Γ))
+      in Hcmx.
+    exact (eq_sym Hcmx).
+  Qed.
+
+  (** §4.18.4 'New note commitment integrity', adversarial reading:
+      [Extract⊥_P(NoteCommit^Orchard_rcm_new(…)) ∈ {cm_x, ⊥}], from
+      acceptance and the new-note short-lookup ranges alone.  The ⊥
+      disjunct is the concrete statement that the witnessed 109-word
+      message drives the [SinsemillaHashToPoint] fold into an exceptional
+      incomplete addition (§5.4.1.9), never a trivial branch. *)
+  Theorem cmx_obligation_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : NoteCommitNewWords.note_commit_new_short_lookup_ok Γ) :
+    cmx_obligation Γ.
+  Proof.
+    unfold cmx_obligation, cmx_bot_of_inputs.
+    destruct (sinsemilla_hash_to_point_bot
+      (OrchardSpec.note_commit_q orchard_circuit_params) (new_msg Γ))
+      as [M |] eqn:Efold.
+    - right.
+      assert (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.note_commit_q orchard_circuit_params) (new_msg Γ)).
+      { apply (proj1 (hash_to_point_bot_iff _ _)).
+        rewrite Efold. discriminate. }
+      rewrite (OrchardCmx_bot_some orchard_circuit_params
+        (OrchardSpec.in_g_d_new (read_action_inputs Γ))
+        (OrchardSpec.in_pk_d_new (read_action_inputs Γ))
+        (OrchardSpec.in_v_new (read_action_inputs Γ))
+        (OrchardProtocolSpec.nullifier
+          (OrchardSpec.in_nk (read_action_inputs Γ))
+          (OrchardSpec.in_rho_old (read_action_inputs Γ))
+          (OrchardSpec.in_psi_old (read_action_inputs Γ))
+          (OrchardSpec.in_cm_old (read_action_inputs Γ)))
+        (OrchardSpec.in_psi_new (read_action_inputs Γ))
+        (OrchardSpec.in_rcm_new (read_action_inputs Γ)) Hnd).
+      exact (f_equal Some (cmx_spec_value Γ Hcircuit Hshort Hnd)).
+    - left.
+      unfold OrchardCmx_bot, note_commit_bot.
+      rewrite Efold.
+      reflexivity.
+  Qed.
+
+  (** ** The old-note lane
+
+      The hashed message of the [Which.Old] hash-to-point region, in the
+      protocol spelling.  [pk_d_old] and [rcm_old] are ownership-track
+      witnesses ([OrchardValidActionInputs] readers), not fields of
+      [read_action_inputs]: no public output depends on them. *)
+
+  Local Notation old_msg Γ :=
+    (OrchardSpec.note_commit_message
+      (OrchardSpec.in_g_d_old (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_pk_d_old Γ)
+      (OrchardSpec.in_v_old (read_action_inputs Γ))
+      (OrchardSpec.in_rho_old (read_action_inputs Γ))
+      (OrchardSpec.in_psi_old (read_action_inputs Γ))).
+
+  Lemma old_note_words_eq (Γ : Assignment.t columns RegionId.t) :
+    OrchardValidActionInputs.old_note_words Γ = OldNoteWords.old_note_words Γ.
+  Proof. reflexivity. Qed.
+
+  Lemma read_pk_d_old_eq (Γ : Assignment.t columns RegionId.t) :
+    OrchardValidActionInputs.read_pk_d_old Γ =
+    read_point Γ
+      (RegionId.AddressIntegrity RegionId.AddressIntegrity.WitnessPkD).
+  Proof. reflexivity. Qed.
+
+  (** The 109 grid words of the [Which.Old] hash-to-point region are the
+      protocol's note-commitment message of the witnessed old-note fields
+      ([OldNoteWords.note_commit_old_words_correct], from acceptance and
+      the old-note short lookups). *)
+  Lemma old_words_protocol
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : OldNoteWords.old_note_short_lookup_ok Γ) :
+    OrchardValidActionInputs.old_note_words Γ = old_msg Γ.
+  Proof.
+    rewrite (old_note_words_eq Γ).
+    rewrite (OldNoteWords.note_commit_old_words_correct Γ Hcircuit Hshort).
+    rewrite (OldNoteOpen.in_g_d_old_read Γ), (read_pk_d_old_eq Γ),
+      (OldNoteOpen.in_v_old_read Γ), (OldNoteOpen.in_rho_old_read Γ),
+      (OldNoteOpen.in_psi_old_read Γ).
+    reflexivity.
+  Qed.
+
+  (** The tracking branch of 'Old note commitment integrity': where the
+      ⊥-carrying fold is defined, the witnessed old-note fields open the
+      witnessed [cm^old]. *)
+  Lemma old_note_spec_value
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : OldNoteWords.old_note_short_lookup_ok Γ)
+      (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.note_commit_q orchard_circuit_params) (old_msg Γ)) :
+    OrchardProtocolSpec.note_commit orchard_circuit_params
+      (OrchardSpec.in_g_d_old (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_pk_d_old Γ)
+      (OrchardSpec.in_v_old (read_action_inputs Γ))
+      (OrchardSpec.in_rho_old (read_action_inputs Γ))
+      (OrchardSpec.in_psi_old (read_action_inputs Γ))
+      (OrchardValidActionInputs.read_rcm_old Γ) =
+    OrchardSpec.in_cm_old (read_action_inputs Γ).
+  Proof.
+    refine (OrchardValidActionInputs.old_note_commit_integrity Γ Hcircuit
+      (conj _ Hshort)).
+    rewrite (old_words_protocol Γ Hcircuit Hshort).
+    exact Hnd.
+  Qed.
+
+  (** §4.18.4 'Old note commitment integrity', adversarial reading:
+      [NoteCommit^Orchard_rcm_old(…) ∈ {cm^old, ⊥}], from acceptance and
+      the old-note short-lookup ranges alone. *)
+  Theorem old_note_obligation_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : OldNoteWords.old_note_short_lookup_ok Γ) :
+    old_note_obligation Γ.
+  Proof.
+    unfold old_note_obligation, old_note_bot_of.
+    destruct (sinsemilla_hash_to_point_bot
+      (OrchardSpec.note_commit_q orchard_circuit_params) (old_msg Γ))
+      as [M |] eqn:Efold.
+    - right.
+      assert (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.note_commit_q orchard_circuit_params) (old_msg Γ)).
+      { apply (proj1 (hash_to_point_bot_iff _ _)).
+        rewrite Efold. discriminate. }
+      rewrite (note_commit_bot_some orchard_circuit_params
+        (OrchardSpec.in_g_d_old (read_action_inputs Γ))
+        (OrchardValidActionInputs.read_pk_d_old Γ)
+        (OrchardSpec.in_v_old (read_action_inputs Γ))
+        (OrchardSpec.in_rho_old (read_action_inputs Γ))
+        (OrchardSpec.in_psi_old (read_action_inputs Γ))
+        (OrchardValidActionInputs.read_rcm_old Γ) Hnd).
+      exact (f_equal Some (old_note_spec_value Γ Hcircuit Hshort Hnd)).
+    - left.
+      unfold note_commit_bot.
+      rewrite Efold.
+      reflexivity.
+  Qed.
+
+End OrchardNoteCommitBot.

--- a/Garden/Orchard/circuit_proof/ownership_bot.v
+++ b/Garden/Orchard/circuit_proof/ownership_bot.v
@@ -1,0 +1,1150 @@
+(** * §4.18.4 'Diversified address integrity', adversarial reading
+
+    The ownership track of the ⊥-disjunctive Action statement: from circuit
+    acceptance alone — no nondegeneracy and no canonicity hypothesis — the
+    §4.18.4 clause
+
+      [ivk = ⊥ or pk_d^old = [ivk] g_d^old],   [ivk = Commit^ivk_rivk(ak, nk)]
+
+    in the form [OrchardAdversarialApi.diversified_address_obligation]
+    ([circuit_proof/adversarial_api.v]).
+
+    The clause's two halves are different in kind.
+
+    - The ⊥ belongs to the [Commit^ivk] Sinsemilla fold and to nothing else.
+      [Commit^ivk] is a [SinsemillaShortCommit], whose hash-to-point is the
+      §5.4.1.9 incomplete-addition fold; on an exceptional operand pair the
+      fold is ⊥ and the gates leave the circuit's value unconstrained.
+      [OrchardProtocolSpecBot.commit_ivk_bot] carries that ⊥, and
+      [OrchardProtocolSpecBot.commit_ivk_bot_defined_iff] identifies
+      definedness with the [SinsemillaHash.nondegenerate] hypothesis the
+      existing chain consumes — so the ⊥ branch is discharged by a case
+      split, with the tracking branch reusing
+      [OrchardValidActionInputs.diversified_address_integrity] verbatim.
+
+    - The variable-base multiplication gets no protocol slack.  §4.18.4's
+      note requires the scalar decomposition of [ivk] in [[ivk] g_d^old] to
+      be canonical, and neither the clause nor its non-normative notes grant
+      the ladder's incomplete additions an exceptional escape.  The mul
+      chip's per-row nondegeneracy side condition
+      ([VarBaseDefs.mul_nondegenerate]) is therefore *derived from the
+      gates* here rather than assumed or disjuncted: at each row of the two
+      incomplete halves the accumulator is a group multiple [[c] B] of the
+      witnessed base, the scalar stays in [1 < c] with [2c + 1 < q_P], and
+      the multiples [[0] B], [[1] B], [[c ± 1] B] are pairwise distinct in
+      their x-coordinates by injectivity of scalar multiplication on
+      residues modulo the prime group order.  The derivation runs inside the
+      round induction, because nondegeneracy at a row follows from the
+      accumulator invariant *at that row*.
+
+    The strengthened round induction is a separate lemma whose conclusion
+    is exactly the [Hnondeg] premise of
+    [VarBaseIncomplete.incomplete_half_generic], so it composes with the
+    half lemmas and their consumers as stated.
+
+    The generic Pallas kit ([pallas_affine_x_nonzero],
+    [repr_x_eq_eq_or_neg], [mul_x_neq]) is restated locally over
+    [EllipticCurve/{Weierstrass,Pallas}.v], the same convention
+    [circuit_proof/ownership/var_base_defs.v] documents for its spec-layer
+    wrappers: the [FixedBaseLadder] originals live in
+    [circuit_proof/ladder/main.v], whose [Require] closure carries the
+    fixed-base certificate leaves. *)
+
+Require Import Stdlib.ZArith.ZArith.
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.micromega.Lia.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.Synthesis.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.PallasModel.
+Require Import Garden.EllipticCurve.Weierstrass.
+Require Import Garden.EllipticCurve.Pallas.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.mul.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete_proof.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Garden.Orchard.circuit.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Orchard.circuit_proof.inputs.
+Require Import Garden.Orchard.circuit_proof.facts.
+Require Import Garden.Orchard.circuit_proof.ownership.var_base_defs.
+Require Import Garden.Orchard.circuit_proof.ownership.var_base_incomplete.
+Require Import Garden.Orchard.circuit_proof.ownership.var_base_mul.
+Require Import Garden.Orchard.circuit_proof.ownership.commit_ivk_hash.
+Require Import Garden.Orchard.circuit_proof.ownership.diversified_address.
+Require Import Garden.Orchard.circuit_proof.valid_action_inputs.
+Require Import Garden.Orchard.circuit_proof.protocol_spec_bot.
+Require Import Garden.Orchard.circuit_proof.adversarial_api.
+(* [Garden.Plonky3.M] is deliberately Require'd but NOT Imported: its
+   notations break nested or-intropatterns.  [Primes] and the
+   [PallasPIsPrime] instance are the [Field.Field] originals. *)
+Require Garden.Plonky3.M.
+Require Import Garden.Field.Field.
+Require Import Garden.Field.Lemmas.
+Require Import Garden.Field.Div.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardOwnershipBot.
+  Import OrchardActionInputs.
+  Import OrchardActionFacts.
+
+  Local Notation Holds Γ :=
+    (circuit_holds Γ
+      Garden.Orchard.circuit.synthesize
+      (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)).
+
+  (** The raw advice reader of the variable-base region, aligned with
+      [VarBaseDefs.av] by [VarBaseIncomplete.av_adv]. *)
+  Local Notation adv Γ c row :=
+    (UnOp.from (Γ.(Assignment.advice) c VarBaseDefs.mul_region row)).
+
+  (** ** Pallas kit, restated locally
+
+      [FixedBaseLadder]'s x-coordinate injectivity chain
+      ([circuit_proof/ladder/main.v]), over
+      [EllipticCurve/{Weierstrass,Pallas}.v] and [Halo2/PallasModel.v]
+      only. *)
+
+  Lemma mul_x_zero {q : Z} `{Prime q} (c x : Z) :
+    UnOp.from x = 0 -> c *F x = 0.
+  Proof.
+    intro Hx. unfold BinOp.mul, UnOp.from in *.
+    rewrite <- Zmult_mod_idemp_r, Hx, Z.mul_0_r. apply Zmod_0_l.
+  Qed.
+
+  Lemma curve_x_zero_absurd {q : Z} `{Prime q} (x y c : Z) :
+    UnOp.from x = 0 ->
+    UnOp.from (y *F y) = UnOp.from (x *F x *F x +F 0 *F x +F c) ->
+    UnOp.from (y *F y) = UnOp.from c.
+  Proof.
+    intros Hx Hc. rewrite Hc.
+    assert (H3 : x *F x *F x = 0) by (apply mul_x_zero; exact Hx).
+    assert (H0x : (0:Z) *F x = 0)
+      by (unfold BinOp.mul; rewrite Z.mul_0_l; apply Zmod_0_l).
+    rewrite H3, H0x.
+    show_equality_modulo.
+  Qed.
+
+  (** No Pallas point has [x = 0]: [b = 5] is a quadratic non-residue
+      (§5.4.9.7 note). *)
+  Lemma pallas_affine_x_nonzero (x y : Z) :
+    Pallas.on_curve (Weierstrass.Affine x y) -> UnOp.from x <> 0.
+  Proof.
+    intros Hc Hx0.
+    cbn [Pallas.on_curve Weierstrass.on_curve] in Hc.
+    unfold Pallas.a, Pallas.b in Hc.
+    apply (EccSpec.pallas_b_quadratic_nonresidue y).
+    change (Garden.Halo2.halo2_gadgets.ecc.chip.constants.pallas_b) with 5.
+    exact (curve_x_zero_absurd x y 5 Hx0 Hc).
+  Qed.
+
+  (** On the curve, [x(P) = x(Q)] iff [P = ±Q]. *)
+  Lemma repr_x_eq_eq_or_neg (P Q : Weierstrass.point) :
+    Pallas.reduced P -> Pallas.reduced Q ->
+    Pallas.on_curve P -> Pallas.on_curve Q ->
+    UnOp.from (Point.x (PallasModel.repr P)) =
+      UnOp.from (Point.x (PallasModel.repr Q)) ->
+    P = Q \/ P = Pallas.neg Q.
+  Proof.
+    intros HPr HQr HPo HQo Hx.
+    destruct P as [| xp yp]; destruct Q as [| xq yq].
+    - left. reflexivity.
+    - exfalso.
+      cbn [PallasModel.repr Point.x EccSpec.identity] in Hx.
+      apply (pallas_affine_x_nonzero xq yq HQo).
+      rewrite <- Hx. reflexivity.
+    - exfalso.
+      cbn [PallasModel.repr Point.x EccSpec.identity] in Hx.
+      apply (pallas_affine_x_nonzero xp yp HPo).
+      rewrite Hx. reflexivity.
+    - cbn [PallasModel.repr Point.x] in Hx.
+      destruct HPr as [Hxp Hyp]. destruct HQr as [Hxq Hyq].
+      assert (Hxeq : xp = xq).
+      { rewrite <- Hxp, <- Hxq. exact Hx. }
+      destruct (Weierstrass.same_x_eq_or_neg Pallas.a Pallas.b
+        (Weierstrass.Affine xp yp) (Weierstrass.Affine xq yq)
+        (conj Hxp Hyp) (conj Hxq Hyq) HPo HQo) as [Heq | Hneg].
+      + cbn [Weierstrass.x_coord]. rewrite Hxeq. reflexivity.
+      + left. exact Heq.
+      + right. exact Hneg.
+  Qed.
+
+  (** Multiples of a prime-order generator with distinct residues [±] have
+      distinct x-coordinates. *)
+  Lemma mul_x_neq (G : Weierstrass.point) (i j : Z)
+      (HGoc : Pallas.on_curve G) (HGred : Pallas.reduced G)
+      (HGne : G <> Pallas.identity)
+      (HGord : Pallas.mul Pallas.pallas_q G = Pallas.identity)
+      (Hij : i mod Pallas.pallas_q <> j mod Pallas.pallas_q)
+      (Hijn : i mod Pallas.pallas_q <> (- j) mod Pallas.pallas_q) :
+    UnOp.from (Point.x (PallasModel.repr (Pallas.mul i G))) <>
+    UnOp.from (Point.x (PallasModel.repr (Pallas.mul j G))).
+  Proof.
+    intro Hx.
+    destruct (repr_x_eq_eq_or_neg (Pallas.mul i G) (Pallas.mul j G)
+      (VarBaseDefs.pallas_mul_reduced i G HGred)
+      (VarBaseDefs.pallas_mul_reduced j G HGred)
+      (VarBaseDefs.pallas_mul_on_curve i G HGoc)
+      (VarBaseDefs.pallas_mul_on_curve j G HGoc) Hx)
+      as [Heq | Hneg].
+    - apply Hij.
+      apply (proj1 (Weierstrass.mul_injective_mod Pallas.a Pallas.b
+        G Pallas.pallas_q VarBaseDefs.pallas_11_lt Pallas.nonsingular
+        HGred HGoc HGne Pallas.pallas_q_is_prime HGord i j)).
+      exact Heq.
+    - apply Hijn.
+      assert (Heq2 : Pallas.mul i G = Pallas.mul (- j) G).
+      { rewrite Hneg. symmetry.
+        exact (Weierstrass.mul_neg Pallas.a Pallas.b j G HGred). }
+      apply (proj1 (Weierstrass.mul_injective_mod Pallas.a Pallas.b
+        G Pallas.pallas_q VarBaseDefs.pallas_11_lt Pallas.nonsingular
+        HGred HGoc HGne Pallas.pallas_q_is_prime HGord i (- j))).
+      exact Heq2.
+  Qed.
+
+  (** ** Small readers of the representation map *)
+
+  Lemma mul_zero_x (G : Weierstrass.point) :
+    UnOp.from (Point.x (PallasModel.repr (Pallas.mul 0 G))) = 0.
+  Proof.
+    unfold Pallas.mul.
+    cbn [Weierstrass.mul PallasModel.repr EccSpec.identity Point.x].
+    unfold UnOp.from. apply Zmod_0_l.
+  Qed.
+
+  (** A represented record whose x is nonzero comes from an affine point. *)
+  Lemma repr_eq_affine (P : Weierstrass.point) (x y : Z) :
+    {| Point.x := x; Point.y := y |} = PallasModel.repr P ->
+    x <> 0 ->
+    P = Weierstrass.Affine x y.
+  Proof.
+    intros Heq Hx.
+    destruct P as [| ax ay].
+    - exfalso. apply Hx. exact (f_equal Point.x Heq).
+    - f_equal.
+      + exact (eq_sym (f_equal Point.x Heq)).
+      + exact (eq_sym (f_equal Point.y Heq)).
+  Qed.
+
+  Lemma pallas_q_lower : 3 < Pallas.pallas_q.
+  Proof.
+    unfold Pallas.pallas_q, Primes.pallas_q.
+    assert (H : 0 < 2 ^ 254) by (apply Z.pow_pos_nonneg; lia).
+    unfold Primes.t_q. lia.
+  Qed.
+
+  Lemma mod_opp_small (a : Z) (Ha : 0 < a < Pallas.pallas_q) :
+    (- a) mod Pallas.pallas_q = Pallas.pallas_q - a.
+  Proof.
+    pose proof pallas_q_lower as Hq.
+    rewrite Z.mod_opp_l_nz.
+    - rewrite (Z.mod_small a) by (clear - Ha; lia). reflexivity.
+    - clear - Hq. lia.
+    - rewrite (Z.mod_small a) by (clear - Ha; lia). clear - Ha. lia.
+  Qed.
+
+  (** ** The per-row nondegeneracy derivation
+
+      At a row whose accumulator represents the multiple [[c] B] of the
+      witnessed base, with the [gradient_1] constraint of
+      [incomplete.q_mul_{2,3}_checks_gate] in force, all three
+      nondegeneracy conjuncts of [VarBaseDefs.step_nondegenerate] are
+      forced.
+
+      - [x_a <> 0]: [[c] B] is not the point at infinity ([0 < c < q_P]),
+        and no Pallas point has [x = 0].
+      - [x_a <> x_p]: [x_p] is the base's x, i.e. [x([1] B)], and
+        [c ≢ ±1 (mod q_P)].
+      - [x_r <> x_a]: with [x_a <> x_p] the [gradient_1] constraint pins
+        [λ₁] to the chord slope from the accumulator to the signed base
+        [[2k−1] B], so [x_r = λ₁² − x_a − x_p] is the x-coordinate of
+        [[c + 2k − 1] B], and [c + 2k − 1 ≢ ±c (mod q_P)] because
+        [0 < 2c ± 1 < q_P].
+
+      The scalar bound [1 < c] with [2c + 1 < q_P] is what the round
+      induction supplies from the running-sum range. *)
+  Lemma step_nondegenerate_derived
+      (B : Pallas.point) (bx byv : Z)
+      (HB : B = Weierstrass.Affine bx byv)
+      (HBred : Pallas.reduced B) (HBoc : Pallas.on_curve B)
+      (HBne : B <> Pallas.identity)
+      (HBord : Pallas.mul Pallas.pallas_q B = Pallas.identity)
+      (c k xa l1 l2 : Z)
+      (Hl1 : UnOp.from l1 = l1)
+      (Hk : k = 0 \/ k = 1)
+      (Hc1 : 1 < c)
+      (Hcq : 2 * c + 1 < Pallas.pallas_q)
+      (Hacc : {| Point.x := xa; Point.y := y_a xa bx l1 l2 |} =
+              PallasModel.repr (Pallas.mul c B))
+      (Hg1 : l1 *F (xa -F bx) -F y_a xa bx l1 l2
+               +F ((k *F UnOp.from 2 -F UnOp.from 1) *F byv) = 0) :
+    xa <> 0 /\ xa <> bx /\ x_r xa bx l1 <> xa.
+  Proof.
+    pose proof pallas_q_lower as Hq3.
+    assert (Hcmod : c mod Pallas.pallas_q = c)
+      by (apply Z.mod_small; clear - Hc1 Hcq Hq3; lia).
+    assert (Hxaeq : Point.x (PallasModel.repr (Pallas.mul c B)) = xa)
+      by (rewrite <- Hacc; reflexivity).
+    (* [x_a <> 0]: the accumulator is not the identity. *)
+    assert (Hxa0 : xa <> 0).
+    { pose proof (mul_x_neq B c 0 HBoc HBred HBne HBord) as Hne.
+      rewrite Z.mod_0_l in Hne by (clear - Hq3; lia).
+      cbn [Z.opp] in Hne.
+      rewrite Z.mod_0_l in Hne by (clear - Hq3; lia).
+      specialize (Hne ltac:(clear - Hcmod Hc1; lia)
+        ltac:(clear - Hcmod Hc1; lia)).
+      rewrite mul_zero_x, Hxaeq in Hne.
+      intro H0. apply Hne. rewrite H0. unfold UnOp.from. apply Zmod_0_l. }
+    (* [x_a <> x_p]: the first chord is not vertical. *)
+    assert (Hxab : xa <> bx).
+    { pose proof (mul_x_neq B c 1 HBoc HBred HBne HBord) as Hne.
+      rewrite (Z.mod_small 1) in Hne by (clear - Hq3; lia).
+      rewrite (mod_opp_small 1) in Hne by (clear - Hq3; lia).
+      specialize (Hne ltac:(clear - Hcmod Hc1; lia)
+        ltac:(clear - Hcmod Hc1 Hcq; lia)).
+      rewrite (VarBaseDefs.pallas_mul_one B) in Hne.
+      rewrite Hxaeq in Hne.
+      rewrite HB in Hne.
+      cbn [PallasModel.repr Point.x] in Hne.
+      intro Hc'. apply Hne. rewrite Hc'. reflexivity. }
+    split; [exact Hxa0 |].
+    split; [exact Hxab |].
+    (* [x_r <> x_a]: the second chord is not vertical. *)
+    assert (HBred' : Pallas.reduced (Weierstrass.Affine bx byv))
+      by (rewrite <- HB; exact HBred).
+    assert (Hbx : UnOp.from bx = bx) by (exact (proj1 HBred')).
+    assert (Hbyv : UnOp.from byv = byv) by (exact (proj2 HBred')).
+    set (Ya := y_a xa bx l1 l2) in *.
+    assert (HYa : UnOp.from Ya = Ya)
+      by (subst Ya; unfold y_a; apply from_mul_reduced).
+    assert (Hxa : UnOp.from xa = xa).
+    { rewrite <- Hxaeq.
+      pose proof (VarBaseDefs.pallas_mul_reduced c B HBred) as HAred.
+      destruct (Pallas.mul c B) as [| ax ay].
+      - cbn [PallasModel.repr EccSpec.identity Point.x].
+        unfold UnOp.from. apply Zmod_0_l.
+      - cbn [PallasModel.repr Point.x]. exact (proj1 HAred). }
+    (* The signed base [[2k−1] B] the row adds, per bit branch. *)
+    assert (Hsigned : exists yb : Z,
+        UnOp.from yb = yb /\
+        VarBaseDefs.signed_base B k = Weierstrass.Affine bx yb /\
+        l1 *F (xa -F bx) = Ya -F yb).
+    { destruct Hk as [-> | ->].
+      - exists (UnOp.opp byv).
+        split; [| split].
+        + unfold UnOp.opp, UnOp.from. apply Z.mod_mod.
+          unfold Primes.pallas_p, Primes.t_p; lia.
+        + unfold VarBaseDefs.signed_base. cbn [Z.eqb].
+          rewrite HB. reflexivity.
+        + assert (Hs : (0 *F UnOp.from 2 -F UnOp.from 1) *F byv = UnOp.opp byv).
+          { unfold UnOp.opp. mod_ring_solve. }
+          rewrite Hs in Hg1.
+          assert (Hmv : l1 *F (xa -F bx) -F (Ya -F UnOp.opp byv) =
+              l1 *F (xa -F bx) -F Ya +F UnOp.opp byv) by mod_ring_solve.
+          rewrite Hg1 in Hmv.
+          apply sub_zero_equiv in Hmv.
+          rewrite from_mul_reduced, from_sub_reduced in Hmv.
+          exact Hmv.
+      - exists byv.
+        split; [| split].
+        + exact Hbyv.
+        + unfold VarBaseDefs.signed_base. cbn [Z.eqb].
+          exact HB.
+        + assert (Hs : (1 *F UnOp.from 2 -F UnOp.from 1) *F byv = UnOp.from byv).
+          { mod_ring_solve. }
+          rewrite Hbyv in Hs.
+          rewrite Hs in Hg1.
+          assert (Hmv : l1 *F (xa -F bx) -F (Ya -F byv) =
+              l1 *F (xa -F bx) -F Ya +F byv) by mod_ring_solve.
+          rewrite Hg1 in Hmv.
+          apply sub_zero_equiv in Hmv.
+          rewrite from_mul_reduced, from_sub_reduced in Hmv.
+          exact Hmv. }
+    destruct Hsigned as (yb & Hyb & Hsb & Hslope1).
+    pose proof (VarBaseIncomplete.chord_add xa Ya bx yb l1
+      Hxa HYa Hbx Hyb Hl1 Hxab Hslope1) as Hchord1.
+    assert (HAaff : Pallas.mul c B = Weierstrass.Affine xa Ya)
+      by (exact (repr_eq_affine (Pallas.mul c B) xa Ya Hacc Hxa0)).
+    (* The step's intermediate point is the multiple [[c + 2k − 1] B]. *)
+    assert (Hsum : Pallas.mul (c + (2 * k - 1)) B =
+        Weierstrass.Affine (x_r xa bx l1) (l1 *F (xa -F x_r xa bx l1) -F Ya)).
+    { rewrite (VarBaseDefs.pallas_mul_add c (2 * k - 1) B HBred HBoc).
+      rewrite <- (VarBaseDefs.signed_base_mul B k HBred Hk).
+      rewrite HAaff, Hsb.
+      rewrite Hchord1.
+      reflexivity. }
+    assert (Hxreq :
+        Point.x (PallasModel.repr (Pallas.mul (c + (2 * k - 1)) B)) =
+        x_r xa bx l1)
+      by (rewrite Hsum; reflexivity).
+    pose proof (mul_x_neq B (c + (2 * k - 1)) c HBoc HBred HBne HBord) as Hne.
+    assert (Hs1 : c + (2 * k - 1) = c - 1 \/ c + (2 * k - 1) = c + 1)
+      by (clear - Hk; destruct Hk as [-> | ->]; [left | right]; lia).
+    assert (Hlo : 0 < c + (2 * k - 1) < Pallas.pallas_q)
+      by (clear - Hs1 Hc1 Hcq Hq3; lia).
+    rewrite (Z.mod_small (c + (2 * k - 1))) in Hne by (clear - Hlo; lia).
+    rewrite (mod_opp_small c) in Hne
+      by (clear - Hc1 Hcq Hq3; lia).
+    specialize (Hne ltac:(clear - Hs1 Hc1 Hcmod; lia)
+      ltac:(clear - Hs1 Hc1 Hcq; lia)).
+    rewrite Hxreq, Hxaeq in Hne.
+    intro Hcc. apply Hne. rewrite Hcc. reflexivity.
+  Qed.
+
+  (** ** The strengthened round induction
+
+      The [n]-step incomplete half with the nondegeneracy premise of
+      [VarBaseIncomplete.incomplete_half_generic] replaced by the base
+      point's order fact and a bound on the multiples the half traverses.
+      Its conclusion is exactly that premise, so it composes directly with
+      [VarBaseIncomplete.hi_half_correct] and [lo_half_correct].
+
+      [Hqcap] is the scalar bound: the invariant multiple at step [j] is
+      [2^(m0+j) + 2 z_{1+j} + 1] with [z_{1+j} < 2^j (z_1 + 1)], so
+      [2 c + 1 <= 2^(m0+n) + 2^(n+1) (z_1 + 1) - 1] for every [j <= n − 1].
+      For the hi half ([m0 = 0], [n = 125], [z_1 = 0]) the bound is
+      [3·2^125]; for the lo half ([m0 = 125], [n = 126],
+      [z_1 < 2^125]) it is [3·2^251] — both far below [q_P ≈ 2^254]. *)
+  Lemma incomplete_half_nondeg
+      (Γ : Assignment.t columns RegionId.t)
+      (q2 q3 : Selector.t) (Zc Xa Xp Yp L1 L2 : Advice.t)
+      (B : Pallas.point) (bx byv : Z)
+      (n m0 : Z)
+      (Hn : 1 <= n)
+      (Hm0 : 0 <= m0)
+      (HB : B = Weierstrass.Affine bx byv)
+      (HBred : Pallas.reduced B)
+      (HBoc : Pallas.on_curve B)
+      (HBne : B <> Pallas.identity)
+      (HBord : Pallas.mul Pallas.pallas_q B = Pallas.identity)
+      (Hbx2 : adv Γ Xp 2 = bx)
+      (Hby2 : adv Γ Yp 2 = byv)
+      (Hcap : 2 ^ n * (adv Γ Zc 1 + 1) <= 2 ^ 254)
+      (Hqcap :
+        2 ^ (m0 + n) + 2 ^ (n + 1) * (adv Γ Zc 1 + 1) < Pallas.pallas_q)
+      (Hacc0 : {| Point.x := adv Γ Xa 2; Point.y := adv Γ L1 1 |} =
+          PallasModel.repr (Pallas.mul (2 ^ m0 + 2 * adv Γ Zc 1 + 1) B))
+      (Hya2 : adv Γ L1 1 =
+          y_a (adv Γ Xa 2) (adv Γ Xp 2) (adv Γ L1 2) (adv Γ L2 2))
+      (Hsel2 : forall r, 2 <= r <= n ->
+          Γ.(Assignment.selector) q2 VarBaseDefs.mul_region r = 1)
+      (Hsel3 : Γ.(Assignment.selector) q3 VarBaseDefs.mul_region (n + 1) = 1)
+      (Hgate2 : forall row : Z, eval_gate Γ (VarBaseDefs.mul_region, row)
+          (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_2_checks_gate
+            q2 Zc Xa Xp Yp L1 L2))
+      (Hgate3 : forall row : Z, eval_gate Γ (VarBaseDefs.mul_region, row)
+          (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_3_checks_gate
+            q3 Zc Xa Xp Yp L1 L2)) :
+    forall r, 2 <= r <= n + 1 ->
+      adv Γ Xa r <> 0 /\
+      adv Γ Xa r <> adv Γ Xp r /\
+      x_r (adv Γ Xa r) (adv Γ Xp r) (adv Γ L1 r) <> adv Γ Xa r.
+  Proof.
+    pose proof pallas_q_lower as Hq3.
+    assert (Hplit : 0 < Primes.pallas_p)
+      by (unfold Primes.pallas_p, Primes.t_p; lia).
+    assert (Hadv_bound : forall (c : Advice.t) (row : Z),
+        0 <= adv Γ c row < Primes.pallas_p)
+      by (intros; unfold UnOp.from; apply Z.mod_pos_bound; exact Hplit).
+    assert (Hadv_red : forall (c : Advice.t) (row : Z),
+        UnOp.from (adv Γ c row) = adv Γ c row)
+      by (intros; apply from_idem).
+    (* The per-row boolean bit, as a field congruence on the running sum. *)
+    assert (Hbitfacts : forall r, 2 <= r <= n + 1 ->
+        exists k, (k = 0 \/ k = 1) /\
+        adv Γ Zc r = (2 * adv Γ Zc (r - 1) + k) mod Primes.pallas_p).
+    { intros r Hr.
+      assert (Hkb : (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2) =
+          Z.b2z (Z.odd (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2))).
+      { destruct (Z.eq_dec r (n + 1)) as [-> | Hne].
+        - pose proof (VarBaseIncomplete.q_mul_3_row_facts Γ q3
+            Zc Xa Xp Yp L1 L2 (n + 1) Hsel3 (Hgate3 (n + 1))) as H3.
+          cbv zeta beta in H3.
+          exact (proj1 H3).
+        - pose proof (VarBaseIncomplete.q_mul_2_row_facts Γ q2
+            Zc Xa Xp Yp L1 L2 r (Hsel2 r ltac:(lia)) (Hgate2 r)) as H2f.
+          cbv zeta beta in H2f.
+          exact (proj1 (proj2 (proj2 H2f))). }
+      assert (Hkv01 : (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2) = 0 \/
+          (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2) = 1).
+      { destruct (Z.odd (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2));
+          cbn in Hkb; [right | left]; exact Hkb. }
+      exists (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2).
+      split; [exact Hkv01 |].
+      assert (Hfe : UnOp.from
+          (2 * adv Γ Zc (r - 1) +
+           (adv Γ Zc r -F adv Γ Zc (r - 1) *F UnOp.from 2)) =
+          UnOp.from (adv Γ Zc r)) by mod_ring_solve.
+      rewrite Hadv_red in Hfe.
+      exact (eq_sym Hfe). }
+    assert (Hbits1 : forall j, 0 <= j < n ->
+        exists k, (k = 0 \/ k = 1) /\
+        adv Γ Zc (1 + j + 1) = (2 * adv Γ Zc (1 + j) + k) mod Primes.pallas_p).
+    { intros j Hj.
+      destruct (Hbitfacts (1 + j + 1) ltac:(lia)) as (k & Hk & He).
+      exists k.
+      split; [exact Hk |].
+      replace (1 + j + 1 - 1) with (1 + j) in He by lia.
+      exact He. }
+    assert (Hz1 : forall j, 0 <= j <= n ->
+        0 <= adv Γ Zc (1 + j) - 2 ^ j * adv Γ Zc 1 < 2 ^ j).
+    { apply (VarBaseIncomplete.running_sum_exact
+        (fun row => adv Γ Zc row) 1 n).
+      - lia.
+      - intros j _. apply Hadv_bound.
+      - exact Hcap.
+      - exact Hbits1. }
+    assert (Hzstep : forall j, 0 <= j < n ->
+        exists k, (k = 0 \/ k = 1) /\
+        adv Γ Zc (1 + j + 1) = 2 * adv Γ Zc (1 + j) + k).
+    { apply (VarBaseIncomplete.running_sum_bits_exact
+        (fun row => adv Γ Zc row) 1 n).
+      - lia.
+      - intros j _. apply Hadv_bound.
+      - exact Hcap.
+      - exact Hbits1. }
+    assert (Hyared : forall xa xp l1 l2 : Z,
+        UnOp.from (y_a xa xp l1 l2) = y_a xa xp l1 l2)
+      by (intros; unfold y_a; apply from_mul_reduced).
+    (* The scalar bound at step [j]. *)
+    assert (Hcbound : forall j, 0 <= j <= n - 1 ->
+        1 < 2 ^ (m0 + j) + 2 * adv Γ Zc (1 + j) + 1 /\
+        2 * (2 ^ (m0 + j) + 2 * adv Γ Zc (1 + j) + 1) + 1 < Pallas.pallas_q).
+    { intros j Hj.
+      pose proof (Hz1 j ltac:(lia)) as Hzj.
+      assert (Hz1nn : 0 <= adv Γ Zc 1) by apply Hadv_bound.
+      assert (Hpowmj : 0 < 2 ^ (m0 + j)) by (apply Z.pow_pos_nonneg; lia).
+      assert (Hpowj : 0 < 2 ^ j) by (apply Z.pow_pos_nonneg; lia).
+      split; [clear - Hzj Hpowmj Hz1nn Hpowj; nia |].
+      assert (Hpowm1 : 2 ^ (m0 + j + 1) = 2 * 2 ^ (m0 + j))
+        by (rewrite Z.pow_add_r by lia; lia).
+      assert (Hpowmn : 2 ^ (m0 + j + 1) <= 2 ^ (m0 + n))
+        by (apply Z.pow_le_mono_r; lia).
+      assert (Hpowj2 : (2:Z) ^ (j + 2) = 4 * 2 ^ j)
+        by (rewrite Z.pow_add_r by lia; lia).
+      assert (Hpowjn : (2:Z) ^ (j + 2) <= 2 ^ (n + 1))
+        by (apply Z.pow_le_mono_r; lia).
+      assert (Hprod : 2 ^ (j + 2) * (adv Γ Zc 1 + 1) <=
+          2 ^ (n + 1) * (adv Γ Zc 1 + 1))
+        by (apply Z.mul_le_mono_nonneg_r; [clear - Hz1nn; lia |
+              clear - Hpowjn; lia]).
+      assert (Hz4 : 4 * adv Γ Zc (1 + j) <=
+          2 ^ (j + 2) * (adv Γ Zc 1 + 1) - 4).
+      { rewrite Hpowj2. clear - Hzj Hpowj. nia. }
+      clear - Hqcap Hpowm1 Hpowmn Hprod Hz4.
+      lia. }
+    (* Nondegeneracy at row [2 + j] from the invariant at [2 + j]. *)
+    assert (Hnd_of_inv : forall j : Z, 0 <= j <= n - 1 ->
+        adv Γ Xp (2 + j) = bx -> adv Γ Yp (2 + j) = byv ->
+        {| Point.x := adv Γ Xa (2 + j);
+           Point.y := y_a (adv Γ Xa (2 + j)) (adv Γ Xp (2 + j))
+                        (adv Γ L1 (2 + j)) (adv Γ L2 (2 + j)) |} =
+          PallasModel.repr
+            (Pallas.mul (2 ^ (m0 + j) + 2 * adv Γ Zc (1 + j) + 1) B) ->
+        adv Γ Xa (2 + j) <> 0 /\
+        adv Γ Xa (2 + j) <> adv Γ Xp (2 + j) /\
+        x_r (adv Γ Xa (2 + j)) (adv Γ Xp (2 + j)) (adv Γ L1 (2 + j)) <>
+          adv Γ Xa (2 + j)).
+    { intros j Hj Hxpr Hypr Hacc.
+      destruct (Hzstep j ltac:(lia)) as (k & Hk & Hstep).
+      replace (1 + j + 1) with (2 + j) in Hstep by lia.
+      assert (Hkv : (adv Γ Zc (2 + j) -F adv Γ Zc (1 + j) *F UnOp.from 2) = k).
+      { rewrite Hstep.
+        destruct Hk as [-> | ->].
+        - transitivity (UnOp.from 0).
+          + mod_ring_solve.
+          + unfold UnOp.from. apply Zmod_0_l.
+        - transitivity (UnOp.from 1).
+          + mod_ring_solve.
+          + unfold UnOp.from. apply Z.mod_small.
+            unfold Primes.pallas_p, Primes.t_p; lia. }
+      assert (Hg1 :
+          adv Γ L1 (2 + j) *F (adv Γ Xa (2 + j) -F adv Γ Xp (2 + j))
+            -F y_a (adv Γ Xa (2 + j)) (adv Γ Xp (2 + j))
+                 (adv Γ L1 (2 + j)) (adv Γ L2 (2 + j))
+            +F (((adv Γ Zc (2 + j) -F adv Γ Zc (2 + j - 1) *F UnOp.from 2)
+                 *F UnOp.from 2 -F UnOp.from 1) *F adv Γ Yp (2 + j)) = 0).
+      { destruct (Z.eq_dec (2 + j) (n + 1)) as [Heqr | Hner].
+        - rewrite Heqr.
+          pose proof (VarBaseIncomplete.q_mul_3_row_facts Γ q3
+            Zc Xa Xp Yp L1 L2 (n + 1) Hsel3 (Hgate3 (n + 1))) as H3.
+          cbv zeta beta in H3.
+          exact (proj1 (proj2 H3)).
+        - pose proof (VarBaseIncomplete.q_mul_2_row_facts Γ q2
+            Zc Xa Xp Yp L1 L2 (2 + j)
+            (Hsel2 (2 + j) ltac:(lia)) (Hgate2 (2 + j))) as H2f.
+          cbv zeta beta in H2f.
+          exact (proj1 (proj2 (proj2 (proj2 H2f)))). }
+      replace (2 + j - 1) with (1 + j) in Hg1 by lia.
+      rewrite Hkv in Hg1.
+      rewrite Hxpr in Hg1, Hacc |- *.
+      rewrite Hypr in Hg1.
+      destruct (Hcbound j Hj) as (Hc1 & Hcq).
+      exact (step_nondegenerate_derived B bx byv HB HBred HBoc HBne HBord
+        (2 ^ (m0 + j) + 2 * adv Γ Zc (1 + j) + 1) k
+        (adv Γ Xa (2 + j)) (adv Γ L1 (2 + j)) (adv Γ L2 (2 + j))
+        (Hadv_red _ _) Hk Hc1 Hcq Hacc Hg1). }
+    (* The accumulator invariant, one step at a time. *)
+    assert (Hinv : forall j, 0 <= j -> j <= n - 1 ->
+        (adv Γ Xp (2 + j) = bx /\ adv Γ Yp (2 + j) = byv) /\
+        {| Point.x := adv Γ Xa (2 + j);
+           Point.y := y_a (adv Γ Xa (2 + j)) (adv Γ Xp (2 + j))
+                        (adv Γ L1 (2 + j)) (adv Γ L2 (2 + j)) |} =
+        PallasModel.repr
+          (Pallas.mul (2 ^ (m0 + j) + 2 * adv Γ Zc (1 + j) + 1) B)).
+    { intros j Hj0.
+      pattern j.
+      revert Hj0.
+      apply natlike_ind.
+      - intros _.
+        replace (2 + 0) with 2 by lia.
+        replace (1 + 0) with 1 by lia.
+        replace (m0 + 0) with m0 by lia.
+        split.
+        + split; [exact Hbx2 | exact Hby2].
+        + rewrite <- Hya2. exact Hacc0.
+      - intros x Hx IH Hsx.
+        specialize (IH ltac:(lia)).
+        destruct IH as [[Hxpr Hypr] Hacc].
+        pose proof (VarBaseIncomplete.q_mul_2_row_facts Γ q2
+          Zc Xa Xp Yp L1 L2 (2 + x)
+          (Hsel2 (2 + x) ltac:(lia)) (Hgate2 (2 + x))) as HF.
+        cbv zeta beta in HF.
+        destruct HF as (Hxp' & Hyp' & _ & Hg1 & Hxan & Hg2).
+        replace (2 + x + 1) with (2 + Z.succ x) in Hxp', Hyp', Hxan, Hg2 by lia.
+        replace (2 + x - 1) with (1 + x) in Hg1 by lia.
+        destruct (Hzstep x ltac:(lia)) as (k & Hk & Hstep).
+        replace (1 + x + 1) with (2 + x) in Hstep by lia.
+        assert (Hkv : (adv Γ Zc (2 + x) -F adv Γ Zc (1 + x) *F UnOp.from 2) = k).
+        { rewrite Hstep.
+          destruct Hk as [-> | ->].
+          - transitivity (UnOp.from 0).
+            + mod_ring_solve.
+            + unfold UnOp.from. apply Zmod_0_l.
+          - transitivity (UnOp.from 1).
+            + mod_ring_solve.
+            + unfold UnOp.from. apply Z.mod_small.
+              unfold Primes.pallas_p, Primes.t_p; lia. }
+        pose proof (Hnd_of_inv x ltac:(lia) Hxpr Hypr Hacc)
+          as (Hnd1 & Hnd2 & Hnd3).
+        rewrite Hkv in Hg1.
+        rewrite Hxpr in Hg1, Hxan, Hg2, Hacc, Hnd2, Hnd3.
+        rewrite Hypr in Hg1.
+        pose proof (VarBaseIncomplete.incomplete_step_group B bx byv
+          HB HBred HBoc
+          (2 ^ (m0 + x) + 2 * adv Γ Zc (1 + x) + 1) k
+          (adv Γ Xa (2 + x)) (adv Γ L1 (2 + x)) (adv Γ L2 (2 + x))
+          (adv Γ Xa (2 + Z.succ x))
+          (y_a (adv Γ Xa (2 + Z.succ x)) (adv Γ Xp (2 + Z.succ x))
+               (adv Γ L1 (2 + Z.succ x)) (adv Γ L2 (2 + Z.succ x)))
+          (Hadv_red _ _) (Hadv_red _ _)
+          (Hyared _ _ _ _)
+          Hk Hacc Hnd1 Hnd2 Hnd3 Hg1 Hxan Hg2) as Hnext.
+        rewrite (VarBaseDefs.step_scalar_shape (m0 + x) (adv Γ Zc (1 + x)) k
+          ltac:(lia)) in Hnext.
+        rewrite <- Hstep in Hnext.
+        replace (m0 + x + 1) with (m0 + Z.succ x) in Hnext by lia.
+        split.
+        + split; [rewrite Hxp'; exact Hxpr | rewrite Hyp'; exact Hypr].
+        + replace (1 + Z.succ x) with (2 + x) by lia.
+          exact Hnext. }
+    intros r Hr.
+    replace r with (2 + (r - 2)) by lia.
+    destruct (Hinv (r - 2) ltac:(lia) ltac:(lia)) as [[Hxpr Hypr] Hacc].
+    exact (Hnd_of_inv (r - 2) ltac:(lia) Hxpr Hypr Hacc).
+  Qed.
+
+  (** ** The two halves, with their nondegeneracy derived
+
+      The region navigations mirror [VarBaseIncomplete.hi_half_correct] and
+      [lo_half_correct] (facts 5–13 and 14–21 of
+      [mul.synthesize_variable_base_scalar_mul_region]); they differ only
+      in the final application, which feeds the nondegeneracy core above
+      rather than the invariant core. *)
+
+  Lemma hi_half_nondeg
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (HBred : Pallas.reduced (VarBaseDefs.base_wpoint Γ))
+      (HBoc : Pallas.on_curve (VarBaseDefs.base_wpoint Γ))
+      (HBne : VarBaseDefs.base_wpoint Γ <> Pallas.identity)
+      (HBord :
+        Pallas.mul Pallas.pallas_q (VarBaseDefs.base_wpoint Γ) =
+          Pallas.identity)
+      (Hinit :
+        {| Point.x := VarBaseDefs.av Γ Advice.A2 1;
+           Point.y := VarBaseDefs.av Γ Advice.A3 1 |} =
+        PallasModel.repr (Pallas.mul 2 (VarBaseDefs.base_wpoint Γ))) :
+    forall r, 2 <= r <= 126 -> VarBaseDefs.hi_step_nondegenerate Γ r.
+  Proof.
+    pose proof (VarBaseDefs.variable_base_region_facts Γ Hcircuit) as Hfacts.
+    pose proof Hfacts as Hz1c.
+    do 5 apply interpret_region_facts_bind_right in Hz1c.
+    apply interpret_region_facts_bind_left in Hz1c.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hz1c.
+    destruct Hz1c as [Hz1c _].
+    pose proof Hfacts as Hsel1.
+    do 6 apply interpret_region_facts_bind_right in Hsel1.
+    apply interpret_region_facts_bind_left in Hsel1.
+    cbn [region_facts interpret_facts interpret_fact] in Hsel1.
+    destruct Hsel1 as [Hsel1 _].
+    pose proof Hfacts as Hblock.
+    do 7 apply interpret_region_facts_bind_right in Hblock.
+    apply interpret_region_facts_bind_left in Hblock.
+    pose proof Hfacts as Hsel3.
+    do 8 apply interpret_region_facts_bind_right in Hsel3.
+    apply interpret_region_facts_bind_left in Hsel3.
+    cbn [region_facts interpret_facts interpret_fact] in Hsel3.
+    destruct Hsel3 as [Hsel3 _].
+    pose proof Hfacts as Hcopy_x.
+    do 10 apply interpret_region_facts_bind_right in Hcopy_x.
+    apply interpret_region_facts_bind_left in Hcopy_x.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_x.
+    destruct Hcopy_x as [Hcopy_x _].
+    pose proof Hfacts as Hcopy_y.
+    do 11 apply interpret_region_facts_bind_right in Hcopy_y.
+    apply interpret_region_facts_bind_left in Hcopy_y.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_y.
+    destruct Hcopy_y as [Hcopy_y _].
+    pose proof Hfacts as Hcopy_bx.
+    do 12 apply interpret_region_facts_bind_right in Hcopy_bx.
+    apply interpret_region_facts_bind_left in Hcopy_bx.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_bx.
+    destruct Hcopy_bx as [Hcopy_bx _].
+    pose proof Hfacts as Hcopy_by.
+    do 13 apply interpret_region_facts_bind_right in Hcopy_by.
+    apply interpret_region_facts_bind_left in Hcopy_by.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_by.
+    destruct Hcopy_by as [Hcopy_by _].
+    cbn in Hz1c, Hcopy_x, Hcopy_y, Hcopy_bx, Hcopy_by.
+    assert (Hz1adv : adv Γ Advice.A9 1 = 0)
+      by (rewrite Hz1c; apply Zmod_0_l).
+    assert (Hcx : adv Γ Advice.A3 2 = adv Γ Advice.A2 1)
+      by (f_equal; exact Hcopy_x).
+    assert (Hcy : adv Γ Advice.A4 1 = adv Γ Advice.A3 1)
+      by (f_equal; exact Hcopy_y).
+    set (bx :=
+      UnOp.from (Γ.(Assignment.advice) Advice.A0 VarBaseDefs.gd_old_region 0)).
+    set (byv :=
+      UnOp.from (Γ.(Assignment.advice) Advice.A1 VarBaseDefs.gd_old_region 0)).
+    assert (Hcbx : adv Γ Advice.A0 2 = bx)
+      by (subst bx; f_equal; exact Hcopy_bx).
+    assert (Hcby : adv Γ Advice.A1 2 = byv)
+      by (subst byv; f_equal; exact Hcopy_by).
+    assert (Hbp : VarBaseDefs.base_point Γ =
+        {| Point.x := Γ.(Assignment.advice) Advice.A0
+             VarBaseDefs.gd_old_region 0 mod Primes.pallas_p;
+           Point.y := Γ.(Assignment.advice) Advice.A1
+             VarBaseDefs.gd_old_region 0 mod Primes.pallas_p |}).
+    { unfold VarBaseDefs.base_point, OrchardActionInputs.read_point,
+        OrchardActionInputs.read, OrchardActionInputs.read1,
+        OrchardActionInputs.read_advice.
+      cbn [Evaluation.eval ExpressionIsEvaluable eval_expression].
+      change (rotated_row 0 Rotation.cur) with 0.
+      reflexivity. }
+    assert (HB : VarBaseDefs.base_wpoint Γ = Weierstrass.Affine bx byv).
+    { unfold VarBaseDefs.base_wpoint.
+      rewrite Hbp.
+      unfold PallasModel.unrepr.
+      cbn [Point.x Point.y].
+      destruct ((Γ.(Assignment.advice) Advice.A0 VarBaseDefs.gd_old_region 0
+          mod Primes.pallas_p =? 0) &&
+        (Γ.(Assignment.advice) Advice.A1 VarBaseDefs.gd_old_region 0
+          mod Primes.pallas_p =? 0))%bool eqn:Hid.
+      - exfalso. apply HBne.
+        unfold VarBaseDefs.base_wpoint.
+        rewrite Hbp.
+        unfold PallasModel.unrepr.
+        cbn [Point.x Point.y].
+        rewrite Hid.
+        reflexivity.
+      - reflexivity. }
+    pose proof (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_1_checks_gate
+          Selector.QMulIncompleteHi1 Advice.A3 Advice.A0 Advice.A4 Advice.A5)
+        VarBaseDefs.mul_region 1
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate1.
+    pose proof (fun row => satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_2_checks_gate
+          Selector.QMulIncompleteHi2 Advice.A9 Advice.A3 Advice.A0 Advice.A1
+          Advice.A4 Advice.A5)
+        VarBaseDefs.mul_region row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate2.
+    pose proof (fun row => satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_3_checks_gate
+          Selector.QMulIncompleteHi3 Advice.A9 Advice.A3 Advice.A0 Advice.A1
+          Advice.A4 Advice.A5)
+        VarBaseDefs.mul_region row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate3.
+    pose proof (QMul1Checks.deterministic Γ VarBaseDefs.mul_region 1
+        Selector.QMulIncompleteHi1 Advice.A3 Advice.A0 Advice.A4 Advice.A5
+        (enabled_nonzero Γ Selector.QMulIncompleteHi1 VarBaseDefs.mul_region 1
+          Hsel1)
+        Hgate1) as Hq1.
+    unfold QMul1Checks.output in Hq1.
+    injection Hq1.
+    intro Hya2raw.
+    cbn [Evaluation.eval ExpressionIsEvaluable eval_expression] in Hya2raw.
+    change (rotated_row 1 Rotation.next) with 2 in Hya2raw.
+    change (rotated_row 1 Rotation.cur) with 1 in Hya2raw.
+    assert (Hcap' : 2 ^ 125 * (adv Γ Advice.A9 1 + 1) <= 2 ^ 254).
+    { rewrite Hz1adv.
+      replace (0 + 1) with 1 by lia.
+      rewrite Z.mul_1_r.
+      apply Z.pow_le_mono_r; lia. }
+    assert (Hqcap' :
+        2 ^ (0 + 125) + 2 ^ (125 + 1) * (adv Γ Advice.A9 1 + 1) <
+          Pallas.pallas_q).
+    { rewrite Hz1adv.
+      replace (0 + 125) with 125 by lia.
+      replace (125 + 1) with 126 by lia.
+      replace (0 + 1) with 1 by lia.
+      rewrite Z.mul_1_r.
+      assert (H125 : (2:Z) ^ 125 <= 2 ^ 253) by (apply Z.pow_le_mono_r; lia).
+      assert (H126 : (2:Z) ^ 126 <= 2 ^ 253) by (apply Z.pow_le_mono_r; lia).
+      assert (H254 : (2:Z) ^ 254 = 2 * 2 ^ 253)
+        by (replace 254 with (Z.succ 253) by lia;
+            rewrite Z.pow_succ_r by lia; lia).
+      unfold Pallas.pallas_q, Primes.pallas_q, Primes.t_q.
+      clear - H125 H126 H254. lia. }
+    assert (Hacc0' :
+        {| Point.x := adv Γ Advice.A3 2; Point.y := adv Γ Advice.A4 1 |} =
+        PallasModel.repr
+          (Pallas.mul (2 ^ 0 + 2 * adv Γ Advice.A9 1 + 1)
+            (VarBaseDefs.base_wpoint Γ))).
+    { rewrite Hcx, Hcy, Hz1adv.
+      replace (2 ^ 0 + 2 * 0 + 1) with 2 by lia.
+      rewrite !VarBaseIncomplete.av_adv in Hinit.
+      exact Hinit. }
+    assert (Hsel2' : forall r, 2 <= r <= 125 ->
+        Γ.(Assignment.selector) Selector.QMulIncompleteHi2
+          VarBaseDefs.mul_region r = 1).
+    { intros r Hr.
+      apply (VarBaseIncomplete.enable_selector_rows_on Γ VarBaseDefs.mul_region
+        Selector.QMulIncompleteHi2 124 2 Hblock).
+      cbn [Z.of_nat Pos.of_succ_nat Pos.succ].
+      lia. }
+    pose proof (incomplete_half_nondeg Γ
+      Selector.QMulIncompleteHi2 Selector.QMulIncompleteHi3
+      Advice.A9 Advice.A3 Advice.A0 Advice.A1 Advice.A4 Advice.A5
+      (VarBaseDefs.base_wpoint Γ) bx byv 125 0
+      ltac:(lia) ltac:(lia) HB HBred HBoc HBne HBord Hcbx Hcby
+      Hcap' Hqcap' Hacc0' Hya2raw Hsel2' Hsel3 Hgate2 Hgate3) as Hmain.
+    intros r Hr.
+    unfold VarBaseDefs.hi_step_nondegenerate, VarBaseDefs.step_nondegenerate.
+    rewrite !VarBaseIncomplete.av_adv.
+    apply Hmain.
+    lia.
+  Qed.
+
+  Lemma lo_half_nondeg
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (HBred : Pallas.reduced (VarBaseDefs.base_wpoint Γ))
+      (HBoc : Pallas.on_curve (VarBaseDefs.base_wpoint Γ))
+      (HBne : VarBaseDefs.base_wpoint Γ <> Pallas.identity)
+      (HBord :
+        Pallas.mul Pallas.pallas_q (VarBaseDefs.base_wpoint Γ) =
+          Pallas.identity)
+      (Hz_hi : 0 <= VarBaseDefs.av Γ Advice.A9 126 < 2 ^ 125)
+      (Hinit :
+        {| Point.x := VarBaseDefs.av Γ Advice.A3 127;
+           Point.y := VarBaseDefs.av Γ Advice.A4 127 |} =
+        PallasModel.repr
+          (Pallas.mul (2 ^ 125 + 2 * VarBaseDefs.av Γ Advice.A9 126 + 1)
+            (VarBaseDefs.base_wpoint Γ))) :
+    forall r, 2 <= r <= 127 -> VarBaseDefs.lo_step_nondegenerate Γ r.
+  Proof.
+    pose proof (VarBaseDefs.variable_base_region_facts Γ Hcircuit) as Hfacts.
+    pose proof Hfacts as Hsel1.
+    do 14 apply interpret_region_facts_bind_right in Hsel1.
+    apply interpret_region_facts_bind_left in Hsel1.
+    cbn [region_facts interpret_facts interpret_fact] in Hsel1.
+    destruct Hsel1 as [Hsel1 _].
+    pose proof Hfacts as Hblock.
+    do 15 apply interpret_region_facts_bind_right in Hblock.
+    apply interpret_region_facts_bind_left in Hblock.
+    pose proof Hfacts as Hsel3.
+    do 16 apply interpret_region_facts_bind_right in Hsel3.
+    apply interpret_region_facts_bind_left in Hsel3.
+    cbn [region_facts interpret_facts interpret_fact] in Hsel3.
+    destruct Hsel3 as [Hsel3 _].
+    pose proof Hfacts as Hcopy_z.
+    do 17 apply interpret_region_facts_bind_right in Hcopy_z.
+    apply interpret_region_facts_bind_left in Hcopy_z.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_z.
+    destruct Hcopy_z as [Hcopy_z _].
+    pose proof Hfacts as Hcopy_x.
+    do 18 apply interpret_region_facts_bind_right in Hcopy_x.
+    apply interpret_region_facts_bind_left in Hcopy_x.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_x.
+    destruct Hcopy_x as [Hcopy_x _].
+    pose proof Hfacts as Hcopy_y.
+    do 19 apply interpret_region_facts_bind_right in Hcopy_y.
+    apply interpret_region_facts_bind_left in Hcopy_y.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_y.
+    destruct Hcopy_y as [Hcopy_y _].
+    pose proof Hfacts as Hcopy_bx.
+    do 20 apply interpret_region_facts_bind_right in Hcopy_bx.
+    apply interpret_region_facts_bind_left in Hcopy_bx.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_bx.
+    destruct Hcopy_bx as [Hcopy_bx _].
+    pose proof Hfacts as Hcopy_by.
+    do 21 apply interpret_region_facts_bind_right in Hcopy_by.
+    apply interpret_region_facts_bind_left in Hcopy_by.
+    cbn [region_facts interpret_facts interpret_fact eval_cell] in Hcopy_by.
+    destruct Hcopy_by as [Hcopy_by _].
+    cbn in Hcopy_z, Hcopy_x, Hcopy_y, Hcopy_bx, Hcopy_by.
+    assert (Hz1lo : adv Γ Advice.A6 1 = adv Γ Advice.A9 126)
+      by (f_equal; exact Hcopy_z).
+    assert (Hcx : adv Γ Advice.A7 2 = adv Γ Advice.A3 127)
+      by (f_equal; exact Hcopy_x).
+    assert (Hcy : adv Γ Advice.A8 1 = adv Γ Advice.A4 127)
+      by (f_equal; exact Hcopy_y).
+    set (bx :=
+      UnOp.from (Γ.(Assignment.advice) Advice.A0 VarBaseDefs.gd_old_region 0)).
+    set (byv :=
+      UnOp.from (Γ.(Assignment.advice) Advice.A1 VarBaseDefs.gd_old_region 0)).
+    assert (Hcbx : adv Γ Advice.A0 2 = bx)
+      by (subst bx; f_equal; exact Hcopy_bx).
+    assert (Hcby : adv Γ Advice.A1 2 = byv)
+      by (subst byv; f_equal; exact Hcopy_by).
+    assert (Hbp : VarBaseDefs.base_point Γ =
+        {| Point.x := Γ.(Assignment.advice) Advice.A0
+             VarBaseDefs.gd_old_region 0 mod Primes.pallas_p;
+           Point.y := Γ.(Assignment.advice) Advice.A1
+             VarBaseDefs.gd_old_region 0 mod Primes.pallas_p |}).
+    { unfold VarBaseDefs.base_point, OrchardActionInputs.read_point,
+        OrchardActionInputs.read, OrchardActionInputs.read1,
+        OrchardActionInputs.read_advice.
+      cbn [Evaluation.eval ExpressionIsEvaluable eval_expression].
+      change (rotated_row 0 Rotation.cur) with 0.
+      reflexivity. }
+    assert (HB : VarBaseDefs.base_wpoint Γ = Weierstrass.Affine bx byv).
+    { unfold VarBaseDefs.base_wpoint.
+      rewrite Hbp.
+      unfold PallasModel.unrepr.
+      cbn [Point.x Point.y].
+      destruct ((Γ.(Assignment.advice) Advice.A0 VarBaseDefs.gd_old_region 0
+          mod Primes.pallas_p =? 0) &&
+        (Γ.(Assignment.advice) Advice.A1 VarBaseDefs.gd_old_region 0
+          mod Primes.pallas_p =? 0))%bool eqn:Hid.
+      - exfalso. apply HBne.
+        unfold VarBaseDefs.base_wpoint.
+        rewrite Hbp.
+        unfold PallasModel.unrepr.
+        cbn [Point.x Point.y].
+        rewrite Hid.
+        reflexivity.
+      - reflexivity. }
+    pose proof (satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_1_checks_gate
+          Selector.QMulIncompleteLo1 Advice.A7 Advice.A0 Advice.A8 Advice.A2)
+        VarBaseDefs.mul_region 1
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate1.
+    pose proof (fun row => satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_2_checks_gate
+          Selector.QMulIncompleteLo2 Advice.A6 Advice.A7 Advice.A0 Advice.A1
+          Advice.A8 Advice.A2)
+        VarBaseDefs.mul_region row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate2.
+    pose proof (fun row => satisfies_gates_at Γ
+        (𝓒.run_unit Garden.Orchard.circuit.configure ConstraintSystem.empty)
+        (Garden.Halo2.halo2_gadgets.ecc.chip.mul.incomplete.q_mul_3_checks_gate
+          Selector.QMulIncompleteLo3 Advice.A6 Advice.A7 Advice.A0 Advice.A1
+          Advice.A8 Advice.A2)
+        VarBaseDefs.mul_region row
+        ltac:(cbn; repeat (first [left; reflexivity | right]))
+        (OrchardActionFacts.holds_gates Γ Hcircuit)) as Hgate3.
+    pose proof (QMul1Checks.deterministic Γ VarBaseDefs.mul_region 1
+        Selector.QMulIncompleteLo1 Advice.A7 Advice.A0 Advice.A8 Advice.A2
+        (enabled_nonzero Γ Selector.QMulIncompleteLo1 VarBaseDefs.mul_region 1
+          Hsel1)
+        Hgate1) as Hq1.
+    unfold QMul1Checks.output in Hq1.
+    injection Hq1.
+    intro Hya2raw.
+    cbn [Evaluation.eval ExpressionIsEvaluable eval_expression] in Hya2raw.
+    change (rotated_row 1 Rotation.next) with 2 in Hya2raw.
+    change (rotated_row 1 Rotation.cur) with 1 in Hya2raw.
+    rewrite !VarBaseIncomplete.av_adv in Hz_hi, Hinit.
+    assert (Hpow251 : (2:Z) ^ 126 * 2 ^ 125 = 2 ^ 251)
+      by (rewrite <- Z.pow_add_r by lia; reflexivity).
+    assert (Hcap' : 2 ^ 126 * (adv Γ Advice.A6 1 + 1) <= 2 ^ 254).
+    { rewrite Hz1lo.
+      assert (Hle : adv Γ Advice.A9 126 + 1 <= 2 ^ 125) by lia.
+      assert (Hmul : 2 ^ 126 * (adv Γ Advice.A9 126 + 1) <= 2 ^ 126 * 2 ^ 125)
+        by (apply Z.mul_le_mono_nonneg_l; lia).
+      assert (Hp3 : (2:Z) ^ 251 <= 2 ^ 254) by (apply Z.pow_le_mono_r; lia).
+      lia. }
+    assert (Hqcap' :
+        2 ^ (125 + 126) + 2 ^ (126 + 1) * (adv Γ Advice.A6 1 + 1) <
+          Pallas.pallas_q).
+    { rewrite Hz1lo.
+      replace (125 + 126) with 251 by lia.
+      replace (126 + 1) with 127 by lia.
+      assert (Hle : adv Γ Advice.A9 126 + 1 <= 2 ^ 125) by lia.
+      assert (Hmul : 2 ^ 127 * (adv Γ Advice.A9 126 + 1) <= 2 ^ 127 * 2 ^ 125)
+        by (apply Z.mul_le_mono_nonneg_l; lia).
+      assert (Hpow252 : (2:Z) ^ 127 * 2 ^ 125 = 2 ^ 252)
+        by (rewrite <- Z.pow_add_r by lia; reflexivity).
+      assert (H251 : (2:Z) ^ 251 <= 2 ^ 253) by (apply Z.pow_le_mono_r; lia).
+      assert (H252 : (2:Z) ^ 252 <= 2 ^ 253) by (apply Z.pow_le_mono_r; lia).
+      assert (H254 : (2:Z) ^ 254 = 2 * 2 ^ 253)
+        by (replace 254 with (Z.succ 253) by lia;
+            rewrite Z.pow_succ_r by lia; lia).
+      unfold Pallas.pallas_q, Primes.pallas_q, Primes.t_q.
+      clear - Hmul Hpow252 H251 H252 H254. lia. }
+    assert (Hacc0' :
+        {| Point.x := adv Γ Advice.A7 2; Point.y := adv Γ Advice.A8 1 |} =
+        PallasModel.repr
+          (Pallas.mul (2 ^ 125 + 2 * adv Γ Advice.A6 1 + 1)
+            (VarBaseDefs.base_wpoint Γ))).
+    { rewrite Hcx, Hcy, Hz1lo.
+      exact Hinit. }
+    assert (Hsel2' : forall r, 2 <= r <= 126 ->
+        Γ.(Assignment.selector) Selector.QMulIncompleteLo2
+          VarBaseDefs.mul_region r = 1).
+    { intros r Hr.
+      apply (VarBaseIncomplete.enable_selector_rows_on Γ VarBaseDefs.mul_region
+        Selector.QMulIncompleteLo2 125 2 Hblock).
+      cbn [Z.of_nat Pos.of_succ_nat Pos.succ].
+      lia. }
+    pose proof (incomplete_half_nondeg Γ
+      Selector.QMulIncompleteLo2 Selector.QMulIncompleteLo3
+      Advice.A6 Advice.A7 Advice.A0 Advice.A1 Advice.A8 Advice.A2
+      (VarBaseDefs.base_wpoint Γ) bx byv 126 125
+      ltac:(lia) ltac:(lia) HB HBred HBoc HBne HBord Hcbx Hcby
+      Hcap' Hqcap' Hacc0' Hya2raw Hsel2' Hsel3 Hgate2 Hgate3) as Hmain.
+    intros r Hr.
+    unfold VarBaseDefs.lo_step_nondegenerate, VarBaseDefs.step_nondegenerate.
+    rewrite !VarBaseIncomplete.av_adv.
+    apply Hmain.
+    lia.
+  Qed.
+
+  (** ** [VarBaseMul.mul_nondegenerate], derived from the gates
+
+      §4.18.4 grants the variable-base multiplication no exceptional
+      escape, and none is needed: on a satisfying assignment every
+      incomplete double-and-add step of the [[ivk] g_d^old] ladder is
+      nondegenerate.  The base facts are themselves circuit-derived — the
+      [QWitnessPointNonId] curve-equation gate at the [GDOld] region
+      ([DiversifiedAddress.base_point_facts]) and the Pallas curve-order
+      theorem ([DiversifiedAddress.base_point_order]). *)
+  Theorem mul_nondegenerate_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ) :
+    VarBaseMul.mul_nondegenerate Γ.
+  Proof.
+    destruct (DiversifiedAddress.base_point_facts Γ Hcircuit)
+      as (HBred & HBoc & HBne).
+    pose proof (DiversifiedAddress.base_point_order Γ Hcircuit) as HBord.
+    pose proof (VarBaseMul.init_acc_correct Γ Hcircuit HBred HBoc) as Hinit.
+    pose proof (hi_half_nondeg Γ Hcircuit HBred HBoc HBne HBord Hinit)
+      as Hhi_nd.
+    pose proof
+      (VarBaseMul.hi_half_correct Γ Hcircuit HBred HBoc HBne Hhi_nd Hinit)
+      as (Hzh_range & _ & Hhi_acc).
+    pose proof
+      (lo_half_nondeg Γ Hcircuit HBred HBoc HBne HBord Hzh_range Hhi_acc)
+      as Hlo_nd.
+    exact (conj Hhi_nd Hlo_nd).
+  Qed.
+
+  (** ** The §4.18.4 clause
+
+      'Diversified address integrity': [ivk = ⊥ or pk_d^old = [ivk] g_d^old].
+      The only hypotheses are circuit acceptance and the [Commit^ivk]
+      short-lookup range family — the relational selector model's residue
+      (the range-check lookup leaves [q_running] free), discharged from
+      operational acceptance by the lookup-closure machinery.  No
+      nondegeneracy hypothesis appears: the Sinsemilla one is replaced by
+      the clause's own ⊥ disjunct, and the mul chip's is derived above. *)
+  Theorem diversified_address_obligation_of_holds
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hshort : CommitIvkHash.commit_ivk_short_lookup_ok Γ) :
+    OrchardAdversarialApi.diversified_address_obligation Γ.
+  Proof.
+    destruct (OrchardAdversarialApi.commit_ivk_bot_of Γ) as [ivk |] eqn:E.
+    2: { left. exact E. }
+    right.
+    exists ivk.
+    split; [exact E |].
+    (* Definedness of the ⊥-carrying commitment is nondegeneracy of the
+       [Commit^ivk] fold. *)
+    assert (Hnd :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.commit_ivk_q orchard_circuit_params)
+          (OrchardSpec.commit_ivk_message
+            (EccSpec.extract_x (OrchardSpec.in_ak (read_action_inputs Γ)))
+            (OrchardSpec.in_nk (read_action_inputs Γ)))).
+    { apply (proj1 (OrchardProtocolSpecBot.commit_ivk_bot_defined_iff
+        orchard_circuit_params
+        (EccSpec.extract_x (OrchardSpec.in_ak (read_action_inputs Γ)))
+        (OrchardSpec.in_nk (read_action_inputs Γ))
+        (OrchardValidActionInputs.read_rivk Γ))).
+      unfold OrchardAdversarialApi.commit_ivk_bot_of in E.
+      rewrite E.
+      discriminate. }
+    (* On the tracking branch the ⊥-carrying commitment is the total one. *)
+    assert (Hivk :
+        ivk =
+        OrchardProtocolSpec.commit_ivk orchard_circuit_params
+          (EccSpec.extract_x (OrchardSpec.in_ak (read_action_inputs Γ)))
+          (OrchardSpec.in_nk (read_action_inputs Γ))
+          (OrchardValidActionInputs.read_rivk Γ)).
+    { unfold OrchardAdversarialApi.commit_ivk_bot_of in E.
+      rewrite (OrchardProtocolSpecBot.commit_ivk_bot_some
+        orchard_circuit_params
+        (EccSpec.extract_x (OrchardSpec.in_ak (read_action_inputs Γ)))
+        (OrchardSpec.in_nk (read_action_inputs Γ))
+        (OrchardValidActionInputs.read_rivk Γ) Hnd) in E.
+      exact (eq_sym
+        (f_equal (fun o : option Z => match o with Some z => z | None => 0 end)
+          E)). }
+    rewrite Hivk.
+    apply (OrchardValidActionInputs.diversified_address_integrity Γ Hcircuit).
+    refine (conj _ (conj Hshort (mul_nondegenerate_of_holds Γ Hcircuit))).
+    change (OrchardValidActionInputs.commit_ivk_words Γ)
+      with (CommitIvkHash.commit_ivk_words Γ).
+    rewrite (CommitIvkHash.commit_ivk_words_correct Γ Hcircuit Hshort).
+    exact Hnd.
+  Qed.
+
+  (** The residue the adversarial assembly re-points: with the mul-chip
+      nondegeneracy derived, [commit_ivk_witness_ok] reduces to the
+      Sinsemilla nondegeneracy and the short-lookup family. *)
+  Theorem commit_ivk_witness_ok_of_nondegenerate
+      (Γ : Assignment.t columns RegionId.t)
+      (Hcircuit : Holds Γ)
+      (Hnondeg :
+        SinsemillaHash.nondegenerate
+          (OrchardSpec.commit_ivk_q orchard_circuit_params)
+          (OrchardValidActionInputs.commit_ivk_words Γ))
+      (Hshort : CommitIvkHash.commit_ivk_short_lookup_ok Γ) :
+    OrchardValidActionInputs.commit_ivk_witness_ok Γ.
+  Proof.
+    exact (conj Hnondeg
+      (conj Hshort (mul_nondegenerate_of_holds Γ Hcircuit))).
+  Qed.
+End OrchardOwnershipBot.

--- a/Garden/Orchard/circuit_proof/protocol_spec_bot.v
+++ b/Garden/Orchard/circuit_proof/protocol_spec_bot.v
@@ -1,0 +1,495 @@
+(** * ⊥-carrying Sinsemilla specification variants
+
+    §4.18.4 'Action Statement (Orchard)' of the Zcash protocol specification
+    ([docs/protocol.pdf]) states its commitment clauses disjunctively —
+    'New note commitment integrity' reads
+    [Extract⊥_P(NoteCommit^Orchard_rcm(…)) ∈ {cm_x, ⊥}], 'Old note commitment
+    integrity' reads [NoteCommit^Orchard_rcm(…) ∈ {cm_old, ⊥}], and
+    'Diversified address integrity' reads [ivk = ⊥ ∨ pk_d = [ivk] g_d] —
+    because §5.4.1.9 'Sinsemilla Hash Function' defines the hash through the
+    partial incomplete addition [⊞], which returns [⊥] on the exceptional
+    operand pairs the circuit's gates do not constrain.
+
+    [Garden/Orchard/protocol_spec.v] transcribes those functions as total
+    functions (on the exceptional cases they compute the chip's chord-formula
+    value); the theorems consuming them select the non-⊥ branch through
+    [SinsemillaHash.nondegenerate] hypotheses.  This file carries the
+    ⊥-carrying ([option]-valued) variants, so the disjunctive protocol
+    clauses can be stated and proved without nondegeneracy hypotheses.
+
+    The entire ⊥ surface of the §4.18.4 output functions is one operation:
+    [EccSpec.point_add_incomplete], reached only through
+    [SinsemillaSpec.round] and [SinsemillaSpec.sinsemilla_hash_to_point].
+    The spend-authority, value-commitment and nullifier functions use
+    complete addition and total group multiples and need no variants; the
+    variants here cover the Sinsemilla chain only — the hash-to-point fold,
+    and the [NoteCommit^Orchard] / [Commit^ivk] / [Extract⊥_P] commitment
+    layers above it ([option_map] shells).
+
+    Design invariant: [round_bot]'s two guards are verbatim the negated
+    conjuncts of [SinsemillaHash.nondegenerate]
+    ([sinsemilla/hash_to_point_proof.v]), so definedness of the ⊥-carrying
+    fold is *equivalent* to nondegeneracy ([hash_to_point_bot_iff]) and
+    every nondegeneracy-conditioned theorem of the total layer is reusable
+    verbatim on the tracking branch.  [protocol_spec.v],
+    [internal_spec.v] and the gadget spec files keep their total
+    functions; the variants live alongside them. *)
+
+Require Import Stdlib.Lists.List.
+Require Import Stdlib.ZArith.ZArith.
+Require Import Garden.Halo2.main.
+Require Import Garden.Halo2.proof.
+Require Import Garden.Halo2.lemmas.
+Require Import Garden.Halo2.halo2_gadgets.ecc.chip.spec.
+Require Garden.Halo2.halo2_gadgets.ecc.chip.constants.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.spec.
+Require Import Garden.Halo2.halo2_gadgets.sinsemilla.hash_to_point_proof.
+Require Import Garden.Orchard.columns.
+Require Import Garden.Orchard.protocol_spec.
+Require Import Garden.Field.Field.
+Require Import Garden.Plonky3.M.
+
+Import ListNotations.
+
+#[local] Existing Instance Primes.PallasPIsPrime.
+
+Global Open Scope Z_scope.
+
+Module OrchardProtocolSpecBot.
+
+  (** ** The ⊥-carrying hash-to-point fold
+
+      §5.4.1.9 defines incomplete addition
+      [⊞ : (P ∪ {⊥}) × (P ∪ {⊥}) → P ∪ {⊥}] with
+      [(x, y) ⊞ (x′, y′) = ⊥ if x = x′], propagates [⊥] through both
+      operand positions, and folds it as
+      [Acc ← (Acc ⊞ 𝒮(m_i)) ⊞ Acc] from [Acc = 𝒬(D)].  [None] is the
+      protocol's [⊥]. *)
+
+  (** One Sinsemilla round, ⊥-carrying: [Acc ← (Acc ⊞ 𝒮(m)) ⊞ Acc]
+      (§5.4.1.9).  The first guard is the exceptional case of
+      [Acc ⊞ 𝒮(m)] (equal x-coordinates), the second that of
+      [(Acc + 𝒮(m)) ⊞ Acc]; they are spelled as the negations of the two
+      conjuncts of [SinsemillaHash.nondegenerate], which is what makes
+      [hash_to_point_bot_iff] an equivalence.  The three identity-operand
+      [⊥] clauses of [⊞] ([𝒪_P ⊞ 𝒪_P], [𝒪_P ⊞ (x′,y′)], [(x,y) ⊞ 𝒪_P])
+      are not spelled here; see [round_bot_no_identity] for why they are
+      unreachable. *)
+  Definition round_bot (acc : option Point.t) (word : Z) : option Point.t :=
+    match acc with
+    | None => None
+    | Some acc =>
+        if Point.x acc =? Point.x (SinsemillaSpec.generator word)
+        then None
+        else if Point.x acc =?
+          Point.x (EccSpec.point_add_incomplete acc (SinsemillaSpec.generator word))
+        then None
+        else
+          Some
+            (EccSpec.point_add_incomplete
+              (EccSpec.point_add_incomplete acc (SinsemillaSpec.generator word))
+              acc)
+    end.
+
+  (** §5.4.1.9 [SinsemillaHashToPoint(D, M) → P ∪ {⊥}]: the left fold of
+      [round_bot] over the message words, seeded by the domain point [Q]. *)
+  Definition sinsemilla_hash_to_point_bot (Q : Point.t) (words : list Z)
+      : option Point.t :=
+    Stdlib.Lists.List.fold_left round_bot words (Some Q).
+
+  (** §5.4.1.9 [SinsemillaHash(D, M) := Extract⊥_P(SinsemillaHashToPoint(D, M))],
+      with §5.4.9.7 [Extract⊥_P(⊥) = ⊥]. *)
+  Definition sinsemilla_hash_bot (Q : Point.t) (words : list Z) : option Z :=
+    option_map EccSpec.extract_x (sinsemilla_hash_to_point_bot Q words).
+
+  (** ** Fold algebra: [None] is absorbing, the fold decomposes at the tail *)
+
+  Lemma round_bot_none (word : Z) : round_bot None word = None.
+  Proof. reflexivity. Qed.
+
+  Lemma round_bot_fold_none (words : list Z) :
+    Stdlib.Lists.List.fold_left round_bot words None = None.
+  Proof.
+    induction words as [| w ws IH]; cbn; [reflexivity | exact IH].
+  Qed.
+
+  Lemma hash_to_point_bot_nil (Q : Point.t) :
+    sinsemilla_hash_to_point_bot Q [] = Some Q.
+  Proof. reflexivity. Qed.
+
+  Lemma hash_to_point_bot_app (Q : Point.t) (words : list Z) (word : Z) :
+    sinsemilla_hash_to_point_bot Q (words ++ [word]) =
+      round_bot (sinsemilla_hash_to_point_bot Q words) word.
+  Proof.
+    unfold sinsemilla_hash_to_point_bot.
+    now rewrite Stdlib.Lists.List.fold_left_app.
+  Qed.
+
+  (** Definedness of the fold is inherited by every prefix — the [None]
+      absorber read backwards. *)
+  Lemma hash_to_point_bot_defined_prefix (Q : Point.t) (ws1 ws2 : list Z) :
+    sinsemilla_hash_to_point_bot Q (ws1 ++ ws2) <> None ->
+    sinsemilla_hash_to_point_bot Q ws1 <> None.
+  Proof.
+    unfold sinsemilla_hash_to_point_bot.
+    rewrite Stdlib.Lists.List.fold_left_app.
+    intros Hdef Hnone.
+    apply Hdef.
+    rewrite Hnone.
+    apply round_bot_fold_none.
+  Qed.
+
+  (** ** §5.4.1.9 fidelity: the identity-operand [⊥] clauses are unreachable
+
+      [round_bot] omits the three [⊞] clauses with an [𝒪_P] operand.  The
+      protocol's own argument (the proof of Theorem 5.4.4, §5.4.1.9): "Since
+      none of 𝒬(D) or {𝒮(j) | j ∈ {0 .. 2^k − 1}} are 𝒪_P, no intermediate
+      results can be 𝒪_P unless one of the preceding conditions occurs" —
+      the preceding conditions being [Acc = ±𝒮(m)] and [Acc + 𝒮(m) = ±Acc],
+      which on the curve are exactly the equal-x guards of [round_bot]
+      ([x(P) = x(Q) ↔ P = ±Q]).  In-model the identity is the [(0, 0)]
+      sentinel ([EccSpec.identity]) and no point satisfying the Pallas curve
+      equation has [x = 0] ([EccSpec.pallas_curve_x_nonzero], from [b = 5]
+      being a quadratic non-residue, §5.4.9.7 note): every on-curve operand
+      — the domain point, every table generator, and every on-curve
+      intermediate accumulator — is distinct from the sentinel
+      ([round_bot_no_identity] below is that step), so the omitted clauses
+      cannot fire on the tracking branch, where every operand stays on the
+      curve. *)
+  Lemma round_bot_no_identity (P : Point.t)
+      (Hcurve :
+        Point.y P *F Point.y P -F (Point.x P *F Point.x P *F Point.x P) -F
+          Garden.Halo2.halo2_gadgets.ecc.chip.constants.pallas_b = 0) :
+    Point.x P <> 0 /\ P <> EccSpec.identity.
+  Proof.
+    pose proof (EccSpec.pallas_curve_x_nonzero (Point.x P) (Point.y P) Hcurve)
+      as Hfrom.
+    assert (Hx : Point.x P <> 0).
+    { intros Hx0. apply Hfrom. rewrite Hx0. reflexivity. }
+    split; [exact Hx |].
+    intros Hid. apply Hx. rewrite Hid. reflexivity.
+  Qed.
+
+  (** ** List helpers for the bridge inductions *)
+
+  Lemma firstn_succ_nth {A : Type} (d : A) :
+    forall (l : list A) (k : nat),
+      (k < List.length l)%nat ->
+      List.firstn (S k) l = List.firstn k l ++ [List.nth k l d].
+  Proof.
+    induction l as [| x l IH]; intros k Hk; cbn in Hk; [lia |].
+    destruct k as [| k]; cbn.
+    - reflexivity.
+    - f_equal. apply IH. lia.
+  Qed.
+
+  (** [nondegenerate] restricts along a tail extension: the first
+      [length words] rounds of [words ++ [word]] are those of [words]. *)
+  Lemma nondegenerate_app_inv (Q : Point.t) (words : list Z) (word : Z) :
+    SinsemillaHash.nondegenerate Q (words ++ [word]) ->
+    SinsemillaHash.nondegenerate Q words.
+  Proof.
+    intros Hnd k Hk.
+    assert (Hk' : (k < List.length (words ++ [word]))%nat)
+      by (rewrite List.length_app; cbn; lia).
+    specialize (Hnd k Hk').
+    cbn zeta in Hnd |- *.
+    rewrite List.firstn_app in Hnd.
+    replace (k - List.length words)%nat with 0%nat in Hnd by lia.
+    cbn [List.firstn] in Hnd.
+    rewrite List.app_nil_r in Hnd.
+    rewrite List.app_nth1 in Hnd by exact Hk.
+    exact Hnd.
+  Qed.
+
+  (** ** The nondegenerate-branch bridge
+
+      On a defined fold, the ⊥-carrying and total layers compute the same
+      point; definedness is equivalent to [SinsemillaHash.nondegenerate].
+      These three lemmas are the whole interface between the ⊥-carrying
+      spec and the nondegeneracy-conditioned theorem surface. *)
+
+  Lemma hash_to_point_bot_some_eq
+      (Q : Point.t) (words : list Z) (acc : Point.t) :
+    sinsemilla_hash_to_point_bot Q words = Some acc ->
+    SinsemillaSpec.sinsemilla_hash_to_point Q words = acc.
+  Proof.
+    revert acc.
+    induction words as [| w ws IH] using List.rev_ind; intros acc Hacc.
+    - cbn in Hacc. injection Hacc as Hacc. subst acc. reflexivity.
+    - rewrite hash_to_point_bot_app in Hacc.
+      rewrite SinsemillaSpec.sinsemilla_hash_to_point_app.
+      destruct (sinsemilla_hash_to_point_bot Q ws) as [b |] eqn:Hb.
+      2: { cbn in Hacc. discriminate. }
+      rewrite (IH b eq_refl).
+      unfold round_bot in Hacc.
+      destruct (Point.x b =? Point.x (SinsemillaSpec.generator w));
+        [discriminate |].
+      destruct (Point.x b =?
+          Point.x (EccSpec.point_add_incomplete b (SinsemillaSpec.generator w)));
+        [discriminate |].
+      injection Hacc as Hacc. subst acc.
+      reflexivity.
+  Qed.
+
+  Lemma hash_to_point_bot_some (Q : Point.t) (words : list Z) :
+    SinsemillaHash.nondegenerate Q words ->
+    sinsemilla_hash_to_point_bot Q words =
+      Some (SinsemillaSpec.sinsemilla_hash_to_point Q words).
+  Proof.
+    induction words as [| w ws IH] using List.rev_ind; intros Hnd.
+    - reflexivity.
+    - rewrite hash_to_point_bot_app.
+      rewrite (IH (nondegenerate_app_inv Q ws w Hnd)).
+      rewrite SinsemillaSpec.sinsemilla_hash_to_point_app.
+      assert (Hlen : (List.length ws < List.length (ws ++ [w]))%nat)
+        by (rewrite List.length_app; cbn; lia).
+      specialize (Hnd (List.length ws) Hlen).
+      cbn zeta in Hnd.
+      rewrite List.firstn_app, List.app_nth2, Nat.sub_diag in Hnd by lia.
+      cbn [List.firstn List.nth] in Hnd.
+      rewrite List.app_nil_r, List.firstn_all in Hnd.
+      destruct Hnd as [Hg1 Hg2].
+      set (a := SinsemillaSpec.sinsemilla_hash_to_point Q ws) in *.
+      unfold round_bot.
+      destruct (Z.eqb_spec (Point.x a) (Point.x (SinsemillaSpec.generator w)))
+        as [E | _]; [exfalso; exact (Hg1 E) |].
+      destruct (Z.eqb_spec (Point.x a)
+          (Point.x (EccSpec.point_add_incomplete a (SinsemillaSpec.generator w))))
+        as [E | _]; [exfalso; exact (Hg2 E) |].
+      unfold SinsemillaSpec.round.
+      reflexivity.
+  Qed.
+
+  Lemma hash_to_point_bot_iff (Q : Point.t) (words : list Z) :
+    sinsemilla_hash_to_point_bot Q words <> None <->
+    SinsemillaHash.nondegenerate Q words.
+  Proof.
+    split.
+    - intros Hdef k Hk.
+      assert (Hpre :
+          sinsemilla_hash_to_point_bot Q (List.firstn (S k) words) <> None).
+      { apply (hash_to_point_bot_defined_prefix Q
+          (List.firstn (S k) words) (List.skipn (S k) words)).
+        rewrite List.firstn_skipn.
+        exact Hdef. }
+      rewrite (firstn_succ_nth 0 words k Hk) in Hpre.
+      rewrite hash_to_point_bot_app in Hpre.
+      destruct (sinsemilla_hash_to_point_bot Q (List.firstn k words))
+        as [b |] eqn:Hb.
+      2: { exfalso. apply Hpre. reflexivity. }
+      pose proof (hash_to_point_bot_some_eq Q (List.firstn k words) b Hb)
+        as Hb_eq.
+      cbn zeta.
+      rewrite Hb_eq.
+      unfold round_bot in Hpre.
+      revert Hpre.
+      destruct (Z.eqb_spec (Point.x b)
+          (Point.x (SinsemillaSpec.generator (List.nth k words 0))))
+        as [E1 | Hne1].
+      { intros Hpre. exfalso. apply Hpre. reflexivity. }
+      destruct (Z.eqb_spec (Point.x b)
+          (Point.x (EccSpec.point_add_incomplete b
+            (SinsemillaSpec.generator (List.nth k words 0)))))
+        as [E2 | Hne2].
+      { intros Hpre. exfalso. apply Hpre. reflexivity. }
+      intros _.
+      exact (conj Hne1 Hne2).
+    - intros Hnd.
+      rewrite (hash_to_point_bot_some Q words Hnd).
+      discriminate.
+  Qed.
+
+  (** The ⊥ branch is a concrete statement about the witnessed word list:
+      the fold is [None] exactly when some round meets an exceptional
+      operand pair. *)
+  Lemma hash_to_point_bot_none_iff (Q : Point.t) (words : list Z) :
+    sinsemilla_hash_to_point_bot Q words = None <->
+    ~ SinsemillaHash.nondegenerate Q words.
+  Proof.
+    split.
+    - intros Hnone Hnd.
+      rewrite (hash_to_point_bot_some Q words Hnd) in Hnone.
+      discriminate.
+    - intros Hnnd.
+      destruct (sinsemilla_hash_to_point_bot Q words) as [b |] eqn:Hb;
+        [| reflexivity].
+      exfalso.
+      apply Hnnd.
+      apply (proj1 (hash_to_point_bot_iff Q words)).
+      rewrite Hb.
+      discriminate.
+  Qed.
+
+  (** ** The commitment layers — [option_map] shells over the fold
+
+      Each is the corresponding [OrchardProtocolSpec] function with the
+      total hash-to-point replaced by the ⊥-carrying one; the layers above
+      the fold (complete addition of the blinding multiple, [Extract_P])
+      are total, so [⊥] only propagates ([option_map]).  The blinding term
+      is the group multiple ([OrchardProtocolSpec.mul_note_commit_r] /
+      [mul_commit_ivk_r]) — the §4.18.4 specification-of-record shape, not
+      the circuit-structured [EccSpec.scalar_mul]. *)
+
+  (** §5.4.8.4 [NoteCommit^Orchard_rcm(g⋆_d, pk⋆_d, v, ρ, ψ)], ⊥-carrying:
+      [⊥] if the [SinsemillaHashToPoint] of the 109-word note message is
+      [⊥], else the hash point blinded by [[rcm] GroupHash^P(D || "-r", "")].
+      Consumed by §4.18.4 'Old note commitment integrity'
+      ([… ∈ {cm_old, ⊥}]). *)
+  Definition note_commit_bot
+      (prm : OrchardSpec.Params) (g_d pk_d : Point.t) (v rho psi rcm : Z)
+      : option Point.t :=
+    option_map
+      (fun M =>
+        EccSpec.point_add M (OrchardProtocolSpec.mul_note_commit_r rcm))
+      (sinsemilla_hash_to_point_bot (OrchardSpec.note_commit_q prm)
+        (OrchardSpec.note_commit_message g_d pk_d v rho psi)).
+
+  (** §5.4.8.4 [Commit^ivk_rivk(ak, nk)] ([SinsemillaShortCommit]),
+      ⊥-carrying.  Consumed by §4.18.4 'Diversified address integrity'
+      ([ivk = ⊥ ∨ pk_d = [ivk] g_d]). *)
+  Definition commit_ivk_bot
+      (prm : OrchardSpec.Params) (ak nk rivk : Z) : option Z :=
+    option_map
+      (fun M =>
+        EccSpec.extract_x
+          (EccSpec.point_add M (OrchardProtocolSpec.mul_commit_ivk_r rivk)))
+      (sinsemilla_hash_to_point_bot (OrchardSpec.commit_ivk_q prm)
+        (OrchardSpec.commit_ivk_message ak nk)).
+
+  (** §4.18.4 'New note commitment integrity':
+      [Extract⊥_P(NoteCommit^Orchard_rcm_new(…)) ∈ {cm_x, ⊥}] — the
+      ⊥-carrying new-note commitment x-coordinate, with §5.4.9.7
+      [Extract⊥_P(⊥) = ⊥]. *)
+  Definition OrchardCmx_bot
+      (prm : OrchardSpec.Params) (g_d_new pk_d_new : Point.t)
+      (v_new rho_new psi_new rcm_new : Z) : option Z :=
+    option_map EccSpec.extract_x
+      (note_commit_bot prm g_d_new pk_d_new v_new rho_new psi_new rcm_new).
+
+  (** ** Shell bridges: on the nondegenerate branch each shell computes
+      [Some] of its total counterpart, and definedness of each shell is
+      definedness of its fold *)
+
+  Lemma option_map_defined_iff {A B : Type} (f : A -> B) (o : option A) :
+    option_map f o <> None <-> o <> None.
+  Proof.
+    destruct o; cbn; split; intros H Hn; congruence.
+  Qed.
+
+  Lemma sinsemilla_hash_bot_some (Q : Point.t) (words : list Z)
+      (Hnd : SinsemillaHash.nondegenerate Q words) :
+    sinsemilla_hash_bot Q words =
+      Some (SinsemillaSpec.sinsemilla_hash Q words).
+  Proof.
+    unfold sinsemilla_hash_bot.
+    rewrite (hash_to_point_bot_some Q words Hnd).
+    cbn [option_map].
+    unfold SinsemillaSpec.sinsemilla_hash.
+    reflexivity.
+  Qed.
+
+  Lemma sinsemilla_hash_bot_defined_iff (Q : Point.t) (words : list Z) :
+    sinsemilla_hash_bot Q words <> None <->
+    SinsemillaHash.nondegenerate Q words.
+  Proof.
+    unfold sinsemilla_hash_bot.
+    exact (iff_trans
+      (option_map_defined_iff EccSpec.extract_x
+        (sinsemilla_hash_to_point_bot Q words))
+      (hash_to_point_bot_iff Q words)).
+  Qed.
+
+  (** The gating bridge: the ⊥-carrying note commitment
+      agrees with [OrchardProtocolSpec.note_commit] whenever its 109-word
+      fold is nondegenerate. *)
+  Lemma note_commit_bot_some
+      (prm : OrchardSpec.Params) (g_d pk_d : Point.t) (v rho psi rcm : Z)
+      (Hnd : SinsemillaHash.nondegenerate
+        (OrchardSpec.note_commit_q prm)
+        (OrchardSpec.note_commit_message g_d pk_d v rho psi)) :
+    note_commit_bot prm g_d pk_d v rho psi rcm =
+      Some (OrchardProtocolSpec.note_commit prm g_d pk_d v rho psi rcm).
+  Proof.
+    unfold note_commit_bot.
+    rewrite (hash_to_point_bot_some _ _ Hnd).
+    cbn [option_map].
+    unfold OrchardProtocolSpec.note_commit.
+    reflexivity.
+  Qed.
+
+  Lemma note_commit_bot_defined_iff
+      (prm : OrchardSpec.Params) (g_d pk_d : Point.t) (v rho psi rcm : Z) :
+    note_commit_bot prm g_d pk_d v rho psi rcm <> None <->
+    SinsemillaHash.nondegenerate
+      (OrchardSpec.note_commit_q prm)
+      (OrchardSpec.note_commit_message g_d pk_d v rho psi).
+  Proof.
+    unfold note_commit_bot.
+    exact (iff_trans
+      (option_map_defined_iff _ _)
+      (hash_to_point_bot_iff _ _)).
+  Qed.
+
+  Lemma commit_ivk_bot_some
+      (prm : OrchardSpec.Params) (ak nk rivk : Z)
+      (Hnd : SinsemillaHash.nondegenerate
+        (OrchardSpec.commit_ivk_q prm)
+        (OrchardSpec.commit_ivk_message ak nk)) :
+    commit_ivk_bot prm ak nk rivk =
+      Some (OrchardProtocolSpec.commit_ivk prm ak nk rivk).
+  Proof.
+    unfold commit_ivk_bot.
+    rewrite (hash_to_point_bot_some _ _ Hnd).
+    cbn [option_map].
+    unfold OrchardProtocolSpec.commit_ivk.
+    reflexivity.
+  Qed.
+
+  Lemma commit_ivk_bot_defined_iff
+      (prm : OrchardSpec.Params) (ak nk rivk : Z) :
+    commit_ivk_bot prm ak nk rivk <> None <->
+    SinsemillaHash.nondegenerate
+      (OrchardSpec.commit_ivk_q prm)
+      (OrchardSpec.commit_ivk_message ak nk).
+  Proof.
+    unfold commit_ivk_bot.
+    exact (iff_trans
+      (option_map_defined_iff _ _)
+      (hash_to_point_bot_iff _ _)).
+  Qed.
+
+  Lemma OrchardCmx_bot_some
+      (prm : OrchardSpec.Params) (g_d_new pk_d_new : Point.t)
+      (v_new rho_new psi_new rcm_new : Z)
+      (Hnd : SinsemillaHash.nondegenerate
+        (OrchardSpec.note_commit_q prm)
+        (OrchardSpec.note_commit_message g_d_new pk_d_new v_new rho_new psi_new)) :
+    OrchardCmx_bot prm g_d_new pk_d_new v_new rho_new psi_new rcm_new =
+      Some (OrchardProtocolSpec.OrchardCmx prm g_d_new pk_d_new
+        v_new rho_new psi_new rcm_new).
+  Proof.
+    unfold OrchardCmx_bot.
+    rewrite (note_commit_bot_some prm g_d_new pk_d_new
+      v_new rho_new psi_new rcm_new Hnd).
+    cbn [option_map].
+    unfold OrchardProtocolSpec.OrchardCmx.
+    reflexivity.
+  Qed.
+
+  Lemma OrchardCmx_bot_defined_iff
+      (prm : OrchardSpec.Params) (g_d_new pk_d_new : Point.t)
+      (v_new rho_new psi_new rcm_new : Z) :
+    OrchardCmx_bot prm g_d_new pk_d_new v_new rho_new psi_new rcm_new <> None <->
+    SinsemillaHash.nondegenerate
+      (OrchardSpec.note_commit_q prm)
+      (OrchardSpec.note_commit_message g_d_new pk_d_new v_new rho_new psi_new).
+  Proof.
+    unfold OrchardCmx_bot.
+    exact (iff_trans
+      (option_map_defined_iff _ _)
+      (note_commit_bot_defined_iff prm g_d_new pk_d_new
+        v_new rho_new psi_new rcm_new)).
+  Qed.
+
+End OrchardProtocolSpecBot.

--- a/Garden/Orchard/circuit_proof/valid_action_inputs.v
+++ b/Garden/Orchard/circuit_proof/valid_action_inputs.v
@@ -637,16 +637,33 @@ Module OrchardValidActionInputs.
       The conjunction of the Action statement's input-side conditions, as a
       Γ-level predicate (the ownership conditions constrain witnesses
       [read_action_inputs] pins to constants, so Γ — not the input record —
-      is the domain).  The first conjunct is §4.18.4's input-typing MUST at
-      circuit granularity; the second is the value-balance binding (the
-      circuit's realization of the [v_old − v_new] argument of 'Value
-      commitment integrity'); then the two enable-flag clauses, the
-      post-NU6.3 cross-address restriction, and the two ownership clauses
-      (honest branches).
+      is the domain).  The first conjunct is
+      [OrchardProtocolEquiv.ProtocolTypedInputs] — the part of §4.18.4's
+      input-typing MUST the protocol equivalence consumes, namely the three
+      full-width scalar ranges ([α], [rcv], [rcm^new] under [8^85]), the
+      [8^22] magnitude bound and the sign condition.  It is *not* the whole
+      §4.18.4 typing surface: the 64-bit bounds on [v_old]/[v_new], the
+      [rcm^old]/[rivk] ranges, the non-identity and on-curve typing of the
+      witnessed points, and the Boolean reading of the enable flags at zero
+      note values are all outside it.  Those facts are assembled — the
+      circuit-derived ones proved, the decoding/consensus ones named — by
+      [OrchardAdversarialApi.typed_inputs_extended] and
+      [OrchardAdversarialApi.WellTypedInstance]
+      ([circuit_proof/adversarial_api.v]).
+
+      The second conjunct is the value-balance binding (the circuit's
+      realization of the [v_old − v_new] argument of 'Value commitment
+      integrity'); then the two enable-flag clauses, the post-NU6.3
+      cross-address restriction, and the two ownership clauses (honest
+      branches).
 
       [OrchardAction.action_statement] ([circuit_proof/main.v]) conjoins
       this with [satisfies_specification]: together they are the in-model
-      formalization of §4.18.4. *)
+      formalization of §4.18.4 on the protocol's non-⊥ branch.  The
+      disjunctive reading, with the exceptional branches in the conclusion
+      and the full typing surface conjoined, is
+      [OrchardAdversarial.action_statement_adversarial]
+      ([circuit_proof/adversarial.v]). *)
   Definition ValidActionInputs (Γ : Assignment.t columns RegionId.t) : Prop :=
     OrchardProtocolEquiv.ProtocolTypedInputs (read_action_inputs Γ) /\
     (OrchardSpec.in_v_old (read_action_inputs Γ) -F

--- a/docs/chip-model-caveats.md
+++ b/docs/chip-model-caveats.md
@@ -467,8 +467,8 @@ instantiation layers are proved:
   short-range rows as a certificate over the event stream, and
   `short_word_sound` then applies. That is the derivation of
   `Orchard/circuit_proof/lookup_closure.v` (with the two companion site
-  inventories `lookup_closure_old_note.v` and `lookup_closure_ivk.v`).
-  What stays open is the
+  inventories `lookup_closure_old_note.v` and `lookup_closure_ivk.v`),
+  consumed by `Orchard/circuit_adversarial.v`. What stays open is the
   relational-level closure: the idealization is real in `proof.v`, and the
   discharge is available only for grid-accepted assignments.
 
@@ -496,7 +496,10 @@ with its concrete placement and constants tail
 (`Orchard/circuit_operational.v`), so the action surface's `Holds`
 hypothesis follows from mock-prover acceptance of the serialized circuit —
 and, at that level, so do the short-lookup halves of the witness-honesty
-hypotheses (`Orchard/circuit_proof/lookup_closure.v` and its companion
-site inventories), leaving the incomplete-add nondegeneracy residue and
-the Merkle package. The remaining open gaps above are the exact trust
-boundary.
+hypotheses (`Orchard/circuit_adversarial.v`), leaving the incomplete-add
+nondegeneracy residue and the Merkle package. That residue is a hypothesis
+only of the equality-shaped statement: the adversarial Action statement of
+the same file states the four affected §4.18.4 clauses disjunctively, as
+the protocol does, and carries no witness-honesty hypothesis at all — so
+the selector-freedom caveat does not reach the strongest statement of the
+surface. The remaining open gaps above are the exact trust boundary.

--- a/docs/chip-model-caveats.md
+++ b/docs/chip-model-caveats.md
@@ -459,9 +459,18 @@ instantiation layers are proved:
   enabled-point indicator, 0 off the enabled points), consumed by
   `Complete.circuit_holds_intro`. It is not yet propagated back into the
   soundness lemmas: the short-lookup form still carries its `q_running = 0`
-  hypothesis explicitly, and folding the default-0 model into the soundness
-  side (so the named short-lookup witness-honesty conditions discharge
-  automatically) remains open.
+  hypothesis explicitly, so within the relational model the named
+  short-lookup witness-honesty conditions do not discharge automatically.
+  One level down they do. The realized assignment reads its selector plane
+  from the replayed grid at absolute rows, so operational acceptance of the
+  pinned Orchard circuit supplies `q_running = 0` at the twenty-five
+  short-range rows as a certificate over the event stream, and
+  `short_word_sound` then applies. That is the derivation of
+  `Orchard/circuit_proof/lookup_closure.v` (with the two companion site
+  inventories `lookup_closure_old_note.v` and `lookup_closure_ivk.v`).
+  What stays open is the
+  relational-level closure: the idealization is real in `proof.v`, and the
+  discharge is available only for grid-accepted assignments.
 
 ## Bottom line
 
@@ -485,5 +494,9 @@ event-replay bridge (`operational_sound`/`operational_complete`,
 `Halo2/realize/sound.v`), instantiated on the whole Orchard action circuit
 with its concrete placement and constants tail
 (`Orchard/circuit_operational.v`), so the action surface's `Holds`
-hypothesis follows from mock-prover acceptance of the serialized circuit;
-the remaining open gaps above are the exact trust boundary.
+hypothesis follows from mock-prover acceptance of the serialized circuit —
+and, at that level, so do the short-lookup halves of the witness-honesty
+hypotheses (`Orchard/circuit_proof/lookup_closure.v` and its companion
+site inventories), leaving the incomplete-add nondegeneracy residue and
+the Merkle package. The remaining open gaps above are the exact trust
+boundary.

--- a/docs/compile-performance.md
+++ b/docs/compile-performance.md
@@ -33,13 +33,22 @@ rocq compile -vok -impredicative-set -R . Garden -w -stdlib-vector \
   Orchard/circuit_proof/ladder/main.v   # checks THIS file vs .vos deps
 ```
 
-**Adding, moving or renaming a `.v` file rebuilds the whole tree.** `Garden/`'s
-top-level `Makefile` computes `VFILES` by `find`, regenerates `CoqMakefile`
-whenever that set changes, and declares `%.vo: CoqMakefile %.v` — so every
-`.vo` in the project is older than the regenerated makefile and is rebuilt,
-including the multi-hour certificate leaves. Deleting `CoqMakefile` by hand
-has the same effect. Batch file moves into a single change and budget a full
-rebuild for it; editing a file *in place* costs only its own dependents.
+**Adding, moving or renaming a `.v` file rebuilds the whole tree — but only
+through the top-level `%.vo` route.** `Garden/`'s top-level `Makefile`
+computes `VFILES` by `find`, regenerates `CoqMakefile` whenever that set
+changes, and declares `%.vo: CoqMakefile %.v` — so asking the *top-level*
+makefile for any `.vo` (`make Orchard/foo.vo`) after the file set changed
+finds it older than the regenerated makefile and rebuilds it, and the same
+holds for deleting `CoqMakefile` by hand. `make` / `make all` does **not**
+take that route: it regenerates `CoqMakefile` and then delegates to
+`make -f CoqMakefile all`, whose own rule is `$(VOFILES): %.vo: %.v |
+$(VDFILE)` — no makefile prerequisite — so an added file costs only itself
+and its dependents (verified 2026-08-03: adding four leaves and running
+`make -j32` reported `Nothing to be done for 'real-all'` once the new files
+had been compiled directly). Batch file moves into a single change anyway,
+and never request an individual `.vo` from the top-level makefile after
+changing the file set; editing a file *in place* always costs only its own
+dependents.
 
 **Honesty constraint.** `.vos`/`-vok`-against-`.vos` trusts the skipped
 dependency proofs. It is a development accelerator only. Any "closed /
@@ -942,6 +951,20 @@ The 2026-07-06 figure (≈ 1 570 s CPU over 275 files,
 `chip_proof` → `hash_to_point_round_proof` → `circuit_proof/merkle.v`)
 predates the completeness-instance layer entirely. Heavy leaves:
 
+- The short-lookup closure leaves (2026-08-03), all cheap:
+  `Orchard/circuit_proof/lookup_closure.v` 4.0 s,
+  `lookup_closure_old_note.v` 1.7 s, `lookup_closure_ivk.v` 1.6 s. Each
+  site inventory is four raw
+  `List.forallb … = true` certificates closed with `vm_cast_no_check`, and
+  their whole cost is forcing the two heavy globals *once per file*: the
+  19,679-event `orchard_events` (≈ 0.5 s, in the `q_running`-absence scan)
+  and the 14,817-fact `layouter_facts circuit.synthesize` (≈ 0.1–0.2 s, in
+  the fact-presence scan). The eleven / eleven / three sites themselves add
+  ≈ 0.01 s of checking. Splitting the three families across files therefore
+  costs ≈ 0.7 s of duplicated forcing each against the merge-by-heavy-global
+  rule above — paid to keep the three families in separate files;
+  merging them is a pure move of definitions and certificates. No
+  sharding is needed at this scale.
 - `Orchard/circuit_operational.v` (2026-07-14): 17.8 s / 1.66 GB peak —
   dominated by `orchard_replay_ok`, a single `vm_cast_no_check` VM run of
   `replay_is_ok` on the 19,679-event Orchard stream (12.3 s before the

--- a/docs/compile-performance.md
+++ b/docs/compile-performance.md
@@ -249,6 +249,33 @@ projection-of-`permute` against a constant-applied-to-`permute`:
 `rewrite <- Hchain` first, so the `permute` application is gone from the
 goal, then `reflexivity`.
 
+**Composing as a term is not an escape when the composed step is a record
+projection.** Elsewhere this file recommends `eq_trans`/`eq_sym`/`f_equal`
+term composition over `rewrite` around heavy constants; that advice stops at
+`f_equal <primitive projection>`. Measured 2026-08-03 in
+`Orchard/circuit_proof/note_commit_bot.v`: closing a `cmx` bridge by
+`exact (eq_trans … (eq_trans (f_equal OrchardSpec.out_cmx (eq_sym Hspec)) …))`
+did not terminate (killed at 600 s wall clock, every other sentence of the
+file at 0.000 s under `-time`). `Primitive Projections` is set globally in
+`Plonky3/M.v`, so `f_equal proj H` hands unification a `Proj` node against a
+projection *application* and it falls back to normalizing the shared
+`orchard_action_spec` argument — the 109-step Sinsemilla fold. Rewriting the
+record equality **inside the hypothesis** first (`rewrite Hspec in Hcmx`,
+then the projection lemma, then `exact (eq_sym Hcmx)`) makes the same step
+0.000 s. Same family, from `merkle_bot.v` the same day:
+`exact (f_equal Point.x Hpoint)` against a goal spelling
+`EccSpec.extract_x (sinsemilla_hash_to_point …)` ran > 100 s before being
+killed; `unfold EccSpec.extract_x; rewrite <- Hpoint; cbn [Point.x];
+reflexivity` — i.e. remove the fold application from the goal before any
+conversion — is instant.
+
+One ordering trap around the same fix: after `with_strategy opaque
+[UnOp.from] cbn` on a goal, `rewrite H` for a hypothesis `H` mentioning the
+same `UnOp.from` term fails with "found no subterm" — the two spellings
+print identically, but `cbn` has normalized the implicit `Prime` instance
+argument. Do every hypothesis rewrite *before* the `cbn`, and use
+`setoid_rewrite` for facts reached through the ring morphisms.
+
 ### Never hand unification sides that differ under a big fold
 
 Never give unification an equation whose sides differ *underneath* a
@@ -953,8 +980,8 @@ predates the completeness-instance layer entirely. Heavy leaves:
 
 - The short-lookup closure leaves (2026-08-03), all cheap:
   `Orchard/circuit_proof/lookup_closure.v` 4.0 s,
-  `lookup_closure_old_note.v` 1.7 s, `lookup_closure_ivk.v` 1.6 s. Each
-  site inventory is four raw
+  `lookup_closure_old_note.v` 1.7 s, `lookup_closure_ivk.v` 1.6 s,
+  `Orchard/circuit_adversarial.v` 1.0 s. Each site inventory is four raw
   `List.forallb … = true` certificates closed with `vm_cast_no_check`, and
   their whole cost is forcing the two heavy globals *once per file*: the
   19,679-event `orchard_events` (≈ 0.5 s, in the `q_running`-absence scan)
@@ -964,7 +991,25 @@ predates the completeness-instance layer entirely. Heavy leaves:
   costs ≈ 0.7 s of duplicated forcing each against the merge-by-heavy-global
   rule above — paid to keep the three families in separate files;
   merging them is a pure move of definitions and certificates. No
-  sharding is needed at this scale.
+  sharding is needed at this scale. `circuit_adversarial.v` computes
+  nothing: it is term composition only.
+- The exceptional-branch (⊥-disjunctive Action statement) leaves
+  (2026-08-03), also cheap: `Orchard/circuit_proof/protocol_spec_bot.v` and
+  `adversarial_api.v` ≈ 1 s each (pure list/`Z` algebra and statements),
+  `note_commit_bot.v` 1.1 s, `ownership_bot.v` 7.5 s (the two duplicated
+  ~120-line half-ladder navigations of the ladder-nondegeneracy
+  derivation),
+  `merkle_bot.v` 8.0 s (the 64 Merkle `b1`/`b2` `ShortSite` certificates
+  cost < 2.5 s of it; the rest is the duplicated per-layer region
+  navigation), `circuit_proof/adversarial.v` 2.5 s and the extended
+  `circuit_adversarial.v` 2.8 s — both term composition plus the five
+  `QWitnessPointNonId` layouter-fact navigations. None carries an
+  input-dependent `vm_compute`. The whole incremental cone of the change
+  (the `valid_action_inputs.v` comment update plus the `cv_net_value.v` /
+  `bundle/` weakening, hence `circuit_operational`, `compiled/*`, `vk/*`,
+  the operational-completeness leaves and the closure files) was 151 s wall
+  / 363 s CPU on a 32-core machine — the low end of the 350–400 s CPU
+  estimate for a touch of that cone.
 - `Orchard/circuit_operational.v` (2026-07-14): 17.8 s / 1.66 GB peak —
   dominated by `orchard_replay_ok`, a single `vm_cast_no_check` VM run of
   `replay_is_ok` on the 19,679-event Orchard stream (12.3 s before the

--- a/docs/operational-soundness.md
+++ b/docs/operational-soundness.md
@@ -148,6 +148,31 @@ The headline theorems:
   replay success, mock acceptance, and the four witness-honesty side
   conditions of `docs/orchard-soundness-proof.md`.
 
+### Closing the short-lookup side conditions (`Orchard/circuit_proof/lookup_closure.v`)
+
+Three of those four side conditions are a nondegeneracy conjunct paired
+with a short-lookup range conjunct, and the short-lookup halves are
+artifacts of the relational selector model rather than real assumptions.
+At this level they are derivable. The realized assignment reads its
+selector plane from the replayed grid at absolute rows, so the pinned event
+stream decides `q_running` at every row; a `forallb` certificate over the
+19,679 events shows it is enabled at none of the twenty-five short-range
+rows, the circuit's single range-check lookup argument
+(`lookup_range_check.configure 10 QLookup QRunning QBitshift A9 TableIdx`)
+therefore collapses to a bare cell read against `table_idx`, and
+`RangeTable.short_word_sound` gives the ten-bit bound, tightened to the
+site's width by the companion bitshift gate.
+
+- `Orchard/circuit_proof/lookup_closure.v` — the selector-absence lemma
+  (`replay_selector_unset`), the extraction (`ten_bit_bound_at`), the
+  width-tightening lemma (`short_range_bound`), the generic per-site lemma
+  `site_short_bound` over an arbitrary `ShortSite` list, and the eleven
+  new-note sites (`note_commit_new_short_lookup_ok_operational`);
+- `Orchard/circuit_proof/lookup_closure_old_note.v`,
+  `Orchard/circuit_proof/lookup_closure_ivk.v` — the eleven `Which.Old`
+  sites and the three `Commit^ivk` sites, each four `forallb` certificates
+  plus a composition through `site_short_bound`.
+
 ## What this strengthens
 
 **The trusted reading of the circuit moves from the model to the mirror of
@@ -393,8 +418,12 @@ distance to a deployed prover is recorded, not hidden:
   `SignatureKnowledge`-style hypothesis, never an axiom. The vk-commitment
   MSM (the compiled polynomials' commitments equal the pinned points) is
   the one remaining byte-level stretch, still deferred.
-- The four witness-honesty side conditions of the action surface, and the
-  model caveats of `docs/chip-model-caveats.md`, apply unchanged.
+- The witness-honesty side conditions of the action surface, and the
+  model caveats of `docs/chip-model-caveats.md`, apply unchanged, with
+  one narrowing: at the operational and algebraic levels the short-lookup
+  halves of three of the four packages are derived rather than assumed
+  (`Orchard/circuit_proof/lookup_closure.v`), leaving the incomplete-add
+  nondegeneracy residue and `merkle_witness_ok`.
 
 ## Theorem index
 
@@ -422,6 +451,8 @@ distance to a deployed prover is recorded, not hidden:
 | `Halo2/plonkish/lookup_poly.v` | `lookup_sound`, `lookup_complete` |
 | `Halo2/plonkish/algebraic.v` | `algebraic_accepts` / `algebraic_accepts_regular`, `algebraic_sound` / `algebraic_sound_regular`, `algebraic_complete` |
 | `Orchard/compiled/algebraic.v` | `orchard_algebraic_sound`, `orchard_algebraic_complete`, `orchard_algebraic_action_statement` |
+| `Orchard/circuit_proof/lookup_closure.v` | `replay_selector_unset`, `ten_bit_bound_at`, `short_range_bound`, `site_short_bound`, `note_commit_new_short_lookup_ok_operational` |
+| `Orchard/circuit_proof/lookup_closure_old_note.v` / `lookup_closure_ivk.v` | `old_note_short_lookup_ok_operational`, `commit_ivk_short_lookup_ok_operational` |
 | `Orchard/circuit_completeness/algebraic.v` | `orchard_honest_algebraic_accepts`, `orchard_honest_algebraic_accepts_ex` (L1 non-vacuity) |
 | `Halo2/plonkish/counting.v` | `vanishing_counting`, `permutation_counting`, `lookup_counting`, per-family bad-set `card_at_most` bounds, `*_accept_cases` |
 | `Halo2/plonkish/boundary.v` | `algebraic_sound_at_challenge`, `algebraic_accepts_at_cases`; named `IPABinding` / `MultiopenReduction` / `FiatShamirChallengeGood` |

--- a/docs/operational-soundness.md
+++ b/docs/operational-soundness.md
@@ -148,7 +148,7 @@ The headline theorems:
   replay success, mock acceptance, and the four witness-honesty side
   conditions of `docs/orchard-soundness-proof.md`.
 
-### Closing the short-lookup side conditions (`Orchard/circuit_proof/lookup_closure.v`)
+### Closing the short-lookup side conditions (`Orchard/circuit_adversarial.v`)
 
 Three of those four side conditions are a nondegeneracy conjunct paired
 with a short-lookup range conjunct, and the short-lookup halves are
@@ -171,7 +171,22 @@ site's width by the companion bitshift gate.
 - `Orchard/circuit_proof/lookup_closure_old_note.v`,
   `Orchard/circuit_proof/lookup_closure_ivk.v` — the eleven `Which.Old`
   sites and the three `Commit^ivk` sites, each four `forallb` certificates
-  plus a composition through `site_short_bound`.
+  plus a composition through `site_short_bound`;
+- `Orchard/circuit_adversarial.v` — `OrchardAdversarialAction`, the two
+  acceptance-level Action statements restated without those conjuncts:
+  `orchard_action_statement_operational_short_closed` here and
+  `orchard_algebraic_action_statement_short_closed` at the
+  polynomial-identity layer below. The residual hypotheses are named one
+  predicate per package (`note_commit_nondegenerate`,
+  `old_note_nondegenerate`, `commit_ivk_nondegenerate`) plus
+  `merkle_witness_ok`, which is not narrowed there: its
+  `merkle_layer_canonical` conjunct bounds 255-bit reconstructions that no
+  acceptance level derives. The same file also carries the adversarial
+  statement — the §4.18.4 clauses in the protocol's own disjunctive form —
+  where none of those residues survives at all
+  (`orchard_action_statement_adversarial_operational` /
+  `…_algebraic`, under `WellTypedInstance` alone); see
+  `docs/orchard-soundness-proof.md`.
 
 ## What this strengthens
 
@@ -420,10 +435,12 @@ distance to a deployed prover is recorded, not hidden:
   the one remaining byte-level stretch, still deferred.
 - The witness-honesty side conditions of the action surface, and the
   model caveats of `docs/chip-model-caveats.md`, apply unchanged, with
-  one narrowing: at the operational and algebraic levels the short-lookup
+  two narrowings: at the operational and algebraic levels the short-lookup
   halves of three of the four packages are derived rather than assumed
-  (`Orchard/circuit_proof/lookup_closure.v`), leaving the incomplete-add
-  nondegeneracy residue and `merkle_witness_ok`.
+  (`Orchard/circuit_adversarial.v`), leaving the incomplete-add
+  nondegeneracy residue and `merkle_witness_ok`; and the adversarial
+  statement in the same file carries no witness-honesty side condition at
+  all, at the cost of the protocol's own disjunctive conclusion.
 
 ## Theorem index
 
@@ -453,6 +470,11 @@ distance to a deployed prover is recorded, not hidden:
 | `Orchard/compiled/algebraic.v` | `orchard_algebraic_sound`, `orchard_algebraic_complete`, `orchard_algebraic_action_statement` |
 | `Orchard/circuit_proof/lookup_closure.v` | `replay_selector_unset`, `ten_bit_bound_at`, `short_range_bound`, `site_short_bound`, `note_commit_new_short_lookup_ok_operational` |
 | `Orchard/circuit_proof/lookup_closure_old_note.v` / `lookup_closure_ivk.v` | `old_note_short_lookup_ok_operational`, `commit_ivk_short_lookup_ok_operational` |
+| `Orchard/circuit_proof/protocol_spec_bot.v` | ⊥-carrying spec variants; `hash_to_point_bot_iff`, the `option_map` commitment shells |
+| `Orchard/circuit_proof/adversarial_api.v` | the four disjunctive §4.18.4 obligations, `typed_inputs_extended`, `WellTypedInstance`, the named Sinsemilla dlog reductions |
+| `Orchard/circuit_proof/note_commit_bot.v` / `ownership_bot.v` / `merkle_bot.v` | `cmx_obligation_of_holds`, `old_note_obligation_of_holds`, `diversified_address_obligation_of_holds`, `mul_nondegenerate_of_holds`, `anchor_obligation_of_holds`, `merkle_b_range_ok_operational` |
+| `Orchard/circuit_proof/adversarial.v` | `action_statement_adversarial`, `deterministic_adversarial`, `typed_inputs_extended_of_holds` |
+| `Orchard/circuit_adversarial.v` | `orchard_action_statement_operational_short_closed`, `orchard_algebraic_action_statement_short_closed`, `orchard_action_statement_adversarial_operational` / `…_algebraic`, `orchard_deterministic_adversarial_operational` / `…_algebraic`, `action_ok_operational` |
 | `Orchard/circuit_completeness/algebraic.v` | `orchard_honest_algebraic_accepts`, `orchard_honest_algebraic_accepts_ex` (L1 non-vacuity) |
 | `Halo2/plonkish/counting.v` | `vanishing_counting`, `permutation_counting`, `lookup_counting`, per-family bad-set `card_at_most` bounds, `*_accept_cases` |
 | `Halo2/plonkish/boundary.v` | `algebraic_sound_at_challenge`, `algebraic_accepts_at_cases`; named `IPABinding` / `MultiopenReduction` / `FiatShamirChallengeGood` |

--- a/docs/orchard-balance-proof.md
+++ b/docs/orchard-balance-proof.md
@@ -38,7 +38,7 @@ Theorem balanced_or_dlog (b : t) (bsk : Z)
 ```
 
 For a bundle whose actions were all accepted by the circuit (with the
-per-action witness-honesty package of the Action-statement theorem), whose
+per-action package `action_ok`), whose
 shape respects the consensus rules — at most `2¹⁶ − 1` actions,
 `value_balance` in the signed 64-bit range — and for which a
 binding-signature opening `bvk = [bsk]·R` is known: **either the hidden
@@ -106,9 +106,15 @@ the audit below).
 ## The hypothesis surface
 
 - **`actions_ok`** — each action satisfies the circuit (`Holds Γ`) plus
-  the witness-honesty package of the Action-statement theorem
-  (`docs/orchard-soundness-proof.md`). The 64-bit value ranges used by the
-  integer lift are derived from circuit satisfaction under that package.
+  the two short-lookup range families that yield the 64-bit `v_old`/`v_new`
+  bounds the integer lift needs. Nothing else: the `cv_net` row is one of
+  the five ⊥-free outputs, so the package carries neither the Merkle
+  package nor any Sinsemilla nondegeneracy. Both families are model
+  artifacts of the relational selector plane and are discharged from
+  acceptance of the pinned circuit
+  (`Garden/Orchard/circuit_proof/lookup_closure.v`,
+  `lookup_closure_old_note.v`), so an accepted action satisfies
+  the package outright.
 - **`side_conditions`** — the two consensus rules used by the lift:
   `n ≤ 2¹⁶ − 1` and `value_balance ∈ [−2⁶³, 2⁶³)`. Both are enforced by
   Zcash consensus outside the circuit.

--- a/docs/orchard-balance-proof.md
+++ b/docs/orchard-balance-proof.md
@@ -112,8 +112,8 @@ the audit below).
   package nor any Sinsemilla nondegeneracy. Both families are model
   artifacts of the relational selector plane and are discharged from
   acceptance of the pinned circuit
-  (`Garden/Orchard/circuit_proof/lookup_closure.v`,
-  `lookup_closure_old_note.v`), so an accepted action satisfies
+  (`OrchardAdversarialAction.action_ok_operational`,
+  `Garden/Orchard/circuit_adversarial.v`), so an accepted action satisfies
   the package outright.
 - **`side_conditions`** — the two consensus rules used by the lift:
   `n ≤ 2¹⁶ − 1` and `value_balance ∈ [−2⁶³, 2⁶³)`. Both are enforced by

--- a/docs/orchard-completeness-proof.md
+++ b/docs/orchard-completeness-proof.md
@@ -17,11 +17,26 @@ a generator that is a function of the honest input.
 
 It does not by itself discharge the four witness-honesty premises
 (`merkle_witness_ok`, `note_commit_witness_ok`, `old_note_witness_ok`,
-`commit_ivk_witness_ok`) that the Action-statement theorem carries. The
+`commit_ivk_witness_ok`) that the equality-shaped Action-statement theorem
+carries. The
 `nondegenerate` clauses below are *shaped* so that reading the generated
 assignment back turns them into those predicates, but the implications are
 not proved; establishing them is what would make this theorem a non-vacuity
-certificate for the Action statement itself rather than for `circuit_holds`.
+certificate for that Action statement itself rather than for
+`circuit_holds`.
+
+Two narrowings (2026-08-03) reduce what is left to establish, without
+changing anything in this document's statements. The short-lookup halves of
+three of those four packages are derived from operational acceptance rather
+than assumed, and the variable-base conjunct of `commit_ivk_witness_ok` is
+a theorem from the gates. And the *adversarial* Action statement
+(`Orchard/circuit_proof/adversarial.v`, carried to the acceptance levels in
+`Orchard/circuit_adversarial.v`) states the four affected §4.18.4 clauses
+disjunctively, as the protocol does, and carries no witness-honesty
+hypothesis at all — so for that statement the C1 instance below is already
+a non-vacuity certificate, and the residual gap concerns only the
+equality-shaped reading. See
+[`orchard-soundness-proof.md`](orchard-soundness-proof.md).
 
 The companion document for the other direction is
 [`orchard-soundness-proof.md`](orchard-soundness-proof.md). Both sit on the

--- a/docs/orchard-soundness-proof.md
+++ b/docs/orchard-soundness-proof.md
@@ -119,12 +119,49 @@ the ANCHOR and CMX outputs would be refutable; naming them keeps this
 model gap visible in the statement. They are the exact residue of the
 selector idealization listed under the model caveats.
 
+The decomposition half of that residue is a property of the relational
+model only, and it is discharged one level down — see *The short-lookup
+conjuncts are discharged at the acceptance levels* below.
+
 **Input typing.** The range envelope under which the circuit-structured
 and protocol layers coincide (full-width scalars in `[0, 8⁸⁵)`, magnitude
 in `[0, 8²²)`, a genuine sign bit) is enforced by the circuit:
 `protocol_typed_inputs_of_holds` derives it from `Holds Γ` alone. The
 theorem therefore carries exactly `Hcircuit` plus the four witness-honesty
 conditions.
+
+## The short-lookup conjuncts are discharged at the acceptance levels
+
+Three of the four witness-honesty packages split into a Sinsemilla or
+variable-base nondegeneracy conjunct and a short-lookup range conjunct:
+
+- `note_commit_witness_ok` = nondegeneracy ∧
+  `NoteCommitNewWords.note_commit_new_short_lookup_ok` (eleven cells);
+- `old_note_witness_ok` = nondegeneracy ∧
+  `OldNoteWords.old_note_short_lookup_ok` (the same eleven at `Which.Old`);
+- `commit_ivk_witness_ok` = nondegeneracy ∧
+  `CommitIvkHash.commit_ivk_short_lookup_ok` (three cells) ∧
+  `VarBaseMul.mul_nondegenerate`.
+
+The twenty-five short-lookup cells are enforced by the deployed circuit and
+are unprovable only in the relational model, where `q_running` is free at
+the firing rows. Operational acceptance closes the gap: the ideal checker
+evaluates the circuit's real range-check lookup argument over the replayed
+grid, and the pinned Orchard event stream enables `q_running` at none of
+the twenty-five rows, so the selector is the initial grid's zero there and
+the lookup input collapses to a bare cell read against `table_idx` (rows
+`0..1023` holding `0..1023`).
+
+`Garden/Orchard/circuit_proof/lookup_closure.v` carries the extraction and
+the width-tightening lemma, one `ShortSite` inventory per family, and four
+`forallb` certificates over the event stream, the region placement, the
+reified synthesis facts and the pinned inverse constants;
+`lookup_closure_old_note.v` and `lookup_closure_ivk.v` are the two further
+site inventories. Each family theorem —
+`note_commit_new_short_lookup_ok_operational`,
+`old_note_short_lookup_ok_operational`,
+`commit_ivk_short_lookup_ok_operational` — takes exactly the premises of
+`orchard_operational_sound`.
 
 ## Corollary: transaction-level balance
 
@@ -206,7 +243,10 @@ how to read these theorems:
 - **Selector freedom at inactive rows.** Where real Halo2 fixes a selector
   column globally, the model constrains it only at rows the synthesis
   program touches. The `q_running` freedom behind the witness-honesty
-  hypotheses is the one place this surfaces in the final statements.
+  hypotheses is the one place this surfaces in the final statements, and
+  it surfaces only in the relational one: at the operational and algebraic
+  levels the whole selector plane is pinned data, and the short-lookup
+  conjuncts it made unprovable are derived there.
 - **Lookup model.** Lookups assert membership in the loaded table with a
   bounded witness row; the table loading and the bound are part of the
   model.

--- a/docs/orchard-soundness-proof.md
+++ b/docs/orchard-soundness-proof.md
@@ -163,6 +163,146 @@ site inventories. Each family theorem —
 `commit_ivk_short_lookup_ok_operational` — takes exactly the premises of
 `orchard_operational_sound`.
 
+`Garden/Orchard/circuit_adversarial.v` (module `OrchardAdversarialAction`)
+restates the two acceptance-level Action statements with those conjuncts
+gone:
+
+```
+Corollary orchard_action_statement_operational_short_closed
+    (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+    (Hreplay : apply_events orchard_events (initial_grid advice instance_)
+                 = Some grid)
+    (Hmock : mock_prover_accepts orchard_indexed_system orchard_events grid
+               orchard_table_rows)
+    (Hmerkle_ok : OrchardActionMerkle.merkle_witness_ok Γ)
+    (Hnote_nd : note_commit_nondegenerate Γ)
+    (Hold_note_nd : old_note_nondegenerate Γ)
+    (Hivk_nd : commit_ivk_nondegenerate Γ) :
+  (read_action_outputs Γ =
+   OrchardProtocolSpec.orchard_action_spec orchard_circuit_params
+     (read_action_inputs Γ)) /\
+  OrchardValidActionInputs.ValidActionInputs Γ.
+```
+
+(with `Γ` for `realize Index.indices region_start_of grid`), and
+`orchard_algebraic_action_statement_short_closed` for the
+polynomial-identity level, whose premises are replay success,
+`orchard_perm_values_canonical`, `orchard_algebraic_accepts` and the same
+four residues. The residues are named one predicate per package
+(`note_commit_nondegenerate`, `old_note_nondegenerate`,
+`commit_ivk_nondegenerate`), so a statement that carries the exceptional
+branches as disjuncts of the conclusion replaces the hypotheses and leaves
+the derivations untouched — which is what the next section does.
+
+What remains hypothesized at these levels is therefore the exceptional-case
+residue only: incomplete-addition nondegeneracy of the three hashed folds,
+plus `merkle_witness_ok`. The variable-base ladder is not among them:
+`OrchardOwnershipBot.mul_nondegenerate_of_holds`
+(`Garden/Orchard/circuit_proof/ownership_bot.v`) derives
+`VarBaseMul.mul_nondegenerate` from the gates, so
+`commit_ivk_nondegenerate` is the Sinsemilla conjunct alone. The Merkle
+package is not narrowed here: its `merkle_layer_canonical` conjunct bounds
+255-bit reconstructions rather than piece ranges, and the deployed
+decomposition gate checks the sum modulo the field prime only.
+
+## The adversarial statement: the clauses as the protocol states them
+
+The equality-shaped conclusion above is the protocol's *non-⊥* branch.
+§4.18.4 does not state four of its clauses as equalities: `NoteCommit` for
+the old and the new note lands in `{cm, ⊥}`, `Commit^ivk` gives
+`ivk = ⊥ ∨ pk_d^old = [ivk] g_d^old`, and Merkle path validity is granted
+the §4.9 escape ("the validity check is permitted to be implemented in
+such a way that it can pass if any hash value on the path, including the
+root, is 0"). The ⊥ member is the exceptional case of the incomplete
+addition `⊞` of §5.4.1.9, which the circuit's gates leave unconstrained by
+design. Unconditional output-equality determinism is therefore *false* of
+the deployed circuit, not merely unproven; the strongest true
+unconditional statement is the disjunctive one.
+
+`Garden/Orchard/circuit_proof/protocol_spec_bot.v` adds ⊥-carrying
+(option-valued) variants of the affected specification functions —
+`round_bot` is `SinsemillaSpec.round` with the two exceptional guards
+returning `None`, and `hash_to_point_bot_iff` proves the fold is defined
+exactly when `SinsemillaHash.nondegenerate` holds, so every existing
+nondegeneracy-conditioned theorem is reused verbatim on the tracking
+branch. `protocol_spec.v` and `internal_spec.v` keep their total
+functions; the variants live alongside them.
+
+`OrchardAdversarialApi` (`circuit_proof/adversarial_api.v`) states the
+four disjunctive obligations, the three exact ⊥-free output clauses, the
+conjoined typing surface `typed_inputs_extended`, and the external premise
+`WellTypedInstance`. Each ⊥ disjunct is a concrete equation
+(`sinsemilla_hash_to_point_bot Q <witnessed words> = None`), never a
+trivial branch. The three track files discharge the obligations from
+`Holds` with no witness-honesty hypothesis at all:
+
+- `note_commit_bot.v` — the two note-commitment clauses;
+- `ownership_bot.v` — 'Diversified address integrity', together with the
+  derivation of `VarBaseMul.mul_nondegenerate` from the gates (§4.18.4
+  grants the multiplication no exceptional escape, and its non-normative
+  note *requires* the `ivk` decomposition to be canonical, so the ladder gets
+  no ⊥ branch);
+- `merkle_bot.v` — the anchor clause as the three-way disjunction "either
+  `v_old = 0`; or some layer's fold is ⊥; or the fold over the witnessed
+  per-layer messages runs from `Extract_P(cm_old)` to the anchor row".
+  The witnessed reading is §4.18.4's own note that "each layer does not
+  check that its input bit sequence is a canonical encoding (in
+  {0 .. q_P − 1}) of the integer from the previous layer"; the middle
+  conjunct of `merkle_layer_canonical` is not slack and is derived
+  outright, the `b_1`/`b_2` pieces being 5-bit short-lookup sites.
+
+`OrchardAdversarial.action_statement_adversarial`
+(`circuit_proof/adversarial.v`) assembles them. Its premises are `Holds`,
+`WellTypedInstance`, and four short-lookup range families;
+`OrchardAdversarialAction.orchard_action_statement_adversarial_operational`
+and `…_algebraic` (`circuit_adversarial.v`) discharge all four families
+from acceptance of the pinned circuit, leaving
+
+```
+Corollary orchard_action_statement_adversarial_operational
+    (advice instance_ : Z -> Z -> Z) (grid : RawGrid.t)
+    (Hreplay : apply_events orchard_events (initial_grid advice instance_)
+                 = Some grid)
+    (Hmock : mock_prover_accepts orchard_indexed_system orchard_events grid
+               orchard_table_rows)
+    (Hwti : OrchardAdversarialApi.WellTypedInstance Γ) :
+  OrchardAdversarialApi.adversarial_action_conclusion Γ.
+```
+
+(again with `Γ` for `realize Index.indices region_start_of grid`).
+
+`WellTypedInstance` has four members, each a fact belonging to transaction
+decoding or consensus rather than to the circuit: Boolean `enableSpends`
+and `enableOutputs` (the gate forces the flag to 1 only when the
+corresponding note value is nonzero), `rk ≠ 𝒪_P` (the §4.6 consensus
+rule, cited by §4.18.4's own note), and reducedness of the decoded
+instance rows. Everything else §4.18.4 asks for is *proved*, not assumed,
+and conjoined by `typed_inputs_extended`: the 64-bit `v_old`/`v_new`
+bounds, the `8²²` magnitude bound and the sign condition, the
+`α`/`rcv`/`rcm^new`/`rcm^old`/`rivk` window ranges, on-curve and
+non-identity for the five points §4.18.4 names (they go through the
+unconditional `QWitnessPointNonId` curve-equation gate, and no Pallas
+point has `x = 0`), on-curve-or-identity for `cm^old`, `[q_P] g_d^old =
+𝒪`, and booleanity of the 32 Merkle position bits.
+
+`OrchardAdversarial.deterministic_adversarial` recovers determinism
+conditioned on inputs alone: two accepted assignments agreeing on
+`read_action_inputs`, on which the ⊥-carrying new-note commitment *of
+those inputs* is defined, agree on every public output row. Definedness is
+a predicate on the input record, not on the witness; on the exceptional
+branch §4.18.4 lets the prover choose `cm_x`, so no determinism statement
+can hold there. `orchard_deterministic_adversarial_operational` and
+`…_algebraic` are the acceptance-level forms.
+
+Two cryptographic readings are *stated and not proved*, as named reduction
+hypotheses in the style of the balance proof's discrete-log reduction:
+`SinsemillaCollisionReduction` (Theorem 5.4.3) and
+`SinsemillaExceptionalDlogReduction` (Theorem 5.4.4), with
+`anchor_exceptional_or_dlog_claim` converting the anchor clause's §4.9
+escape into an explicit discrete-logarithm disjunct. They are `Definition`s
+of statements, never `Admitted` lemmas, and nothing in the development
+consumes them.
+
 ## Corollary: transaction-level balance
 
 Because every accepted action provably commits to exactly
@@ -201,7 +341,11 @@ ceiling and the spec-anchored pipeline coefficients).
   vacuous. It does not discharge the four witness-honesty premises at that
   assignment: the honest generator's non-degeneracy clauses are shaped to
   imply them, but the implications are not proved, so the non-vacuity
-  argument for these four hypotheses specifically remains meta-level.
+  argument for these four hypotheses specifically remains meta-level. At
+  the operational and algebraic levels the short-lookup halves are not
+  hypotheses at all, so this concerns the nondegeneracy residue and
+  the Merkle package there — and the adversarial statement carries neither,
+  at the cost of a disjunctive conclusion.
 - **Proving-system soundness.** That a verifier accepting a Halo 2 proof
   implies the existence of a satisfying assignment is a property of the
   proving system, not of the circuit, and is not claimed here.
@@ -213,7 +357,9 @@ ceiling and the spec-anchored pipeline coefficients).
   at the whole Orchard circuit: `orchard_operational_sound` carries acceptance
   by the ideal `mock_prover_accepts` checker back to `Holds`,
   `orchard_action_statement_operational` composes that result with the Action
-  statement above, and `orchard_operational_complete` carries an honest
+  statement above (with the short-lookup conjuncts removed in
+  `orchard_action_statement_operational_short_closed`), and
+  `orchard_operational_complete` carries an honest
   witness forward to the checker. The checker itself remains an idealization:
   it quantifies over all integer rows and is not the deployed cryptographic
   prover. Below it, the same Action conclusion is available from the compiled

--- a/docs/orchard-soundness-proof.md
+++ b/docs/orchard-soundness-proof.md
@@ -301,7 +301,13 @@ hypotheses in the style of the balance proof's discrete-log reduction:
 `anchor_exceptional_or_dlog_claim` converting the anchor clause's §4.9
 escape into an explicit discrete-logarithm disjunct. They are `Definition`s
 of statements, never `Admitted` lemmas, and nothing in the development
-consumes them.
+consumes them. The underlying relation `sinsemilla_dlog_relation` is
+canonical — one aggregate coefficient per table generator, with
+nontriviality stated on those aggregates — so a witness supported outside
+the table (where the total lookup reads the identity sentinel) or with
+cancelling occurrences of one generator exhibits no relation;
+`sparse_out_of_range_rejected` and `sparse_cancellation_rejected` are the
+regression lemmas for those two degenerate shapes.
 
 ## Corollary: transaction-level balance
 


### PR DESCRIPTION
# Orchard: the adversarial Action statement — §4.18.4 with no witness-honesty hypotheses

The Orchard Action-statement theorem has, until now, been conditional: *if the circuit accepts and the witness is honest in four named ways, the outputs satisfy §4.18.4.* The four witness-honesty packages were the main caveat on the claim — an adversarial prover does not promise honesty. This PR removes that conditionality in two steps, one per commit: the range halves of the packages are **derived** from acceptance of the pinned circuit, and the exceptional-case halves are **absorbed into the conclusion** by proving the §4.18.4 clauses in the disjunctive form the protocol itself states them. The headline result is `orchard_action_statement_adversarial_operational` (and its polynomial-identity twin `…_algebraic`) in `Garden/Orchard/circuit_adversarial.v`: acceptance of the pinned Orchard circuit implies the §4.18.4 clause set, under the single premise `WellTypedInstance` — a typing fact about the decoded public input that belongs to transaction decoding and consensus, not to the circuit. The new sections of [`docs/orchard-soundness-proof.md`](https://github.com/formal-land/garden/blob/valerii-huhnin%40exceptional-branch/docs/orchard-soundness-proof.md) are the claim surface and the recommended starting point.

**Step 1: the short-lookup conjuncts were model artifacts, and are now theorems.** Three of the four packages split into a nondegeneracy conjunct and a short-lookup range conjunct (eleven cells for the new-note commitment, eleven for the old, three for `Commit^ivk`). The deployed circuit enforces all twenty-five through its range-check lookup argument; they were hypotheses only because the relational selector model leaves `q_running` free at the firing rows. At the operational level the selector plane is pinned data, so the gap closes: the pinned event stream enables `q_running` at none of the twenty-five rows, the lookup input collapses to a bare cell read against the `table_idx` column, and `Garden/Orchard/circuit_proof/lookup_closure{,_old_note,_ivk}.v` derive each family from replay success and ideal acceptance — a generic `ShortSite` derivation plus four `vm_compute` certificates per family over the event stream, placement, synthesis facts and pinned inverse constants. `orchard_action_statement_operational_short_closed` and `orchard_algebraic_action_statement_short_closed` restate the two acceptance-level Action statements with those conjuncts gone. This also simplifies the balance stack: `bundle/spec.v`'s `action_ok` package is now discharged outright from acceptance (`action_ok_operational`), and the per-action `cv_net` facts drop their Merkle and note-commitment hypotheses entirely.

**Step 2: the exceptional branches become disjuncts, as the protocol writes them.** §4.18.4 does not state four of its clauses as equalities: `NoteCommit` for both notes lands in `{cm, ⊥}`, `Commit^ivk` gives `ivk = ⊥ ∨ pk_d = [ivk] g_d`, and Merkle path validity has the §4.9 escape. The ⊥ member is the exceptional case of Sinsemilla's incomplete addition `⊞` (§5.4.1.9), which the gates leave unconstrained by design — so unconditional output-equality determinism is *false* of the deployed circuit, not merely unproven, and the disjunctive statement is the strongest true unconditional one. `protocol_spec_bot.v` adds ⊥-carrying (option-valued) variants of the affected spec functions, with `hash_to_point_bot_iff` proving definedness exactly equivalent to the existing `nondegenerate` predicate so every nondegeneracy-conditioned theorem is reused verbatim on the defined branch. The track files then discharge each disjunctive clause from circuit satisfaction with no honesty hypothesis: `note_commit_bot.v` (both commitment clauses), `ownership_bot.v` ('Diversified address integrity' — and here the variable-base mul ladder gets **no** ⊥ branch: §4.18.4 grants that multiplication no exceptional escape, and `mul_nondegenerate_of_holds` derives the chip's nondegeneracy from the gates), and `merkle_bot.v` (the anchor clause as "either `v_old = 0`, or some layer's fold is ⊥, or the witnessed fold runs from `Extract_P(cm_old)` to the anchor" — with the 64 `b_1`/`b_2` five-bit pieces closed as further short-lookup sites). Every ⊥ disjunct is a concrete equation (`… = None`), never a trivially-true branch.

**What remains assumed is small and external.** `WellTypedInstance` has four members: Boolean `enableSpends`/`enableOutputs`, the `rk ≠ 𝒪_P` consensus rule (§4.6, cited by §4.18.4's own note), and reducedness of the decoded instance rows. Everything else §4.18.4 asks of the inputs is proved and conjoined in `typed_inputs_extended` — value bounds, window ranges, on-curve and non-identity for the five points the section names, booleanity of the 32 position bits. Two cryptographic readings of the anchor escape are stated as named reduction hypotheses in the style of the balance proof's discrete-log reduction (`SinsemillaCollisionReduction`, `SinsemillaExceptionalDlogReduction`, per Theorems 5.4.3/5.4.4) — `Definition`s of statements, never `Admitted`, and nothing in the development consumes them.

**Determinism is recovered, conditioned on the inputs alone.** `deterministic_adversarial`: two accepted assignments agreeing on the decoded inputs, on which the ⊥-carrying commitment *of those inputs* is defined, agree on every public output row. Definedness is a predicate on the input record, not the witness; on the exceptional branch §4.18.4 lets the prover choose `cm_x`, so no determinism statement can hold there. `orchard_deterministic_adversarial_operational`/`…_algebraic` are the acceptance-level forms.

Everything is `Qed` — no `Admitted`, `Axiom` or `admit` anywhere in the new files — and `Print Assumptions` on the new corollaries reports the same baseline as the existing acceptance-level theorems (`PrimString.string` plus impredicative `Set`).

## How to review

1. **What is claimed** — the two new sections of `docs/orchard-soundness-proof.md` ("The short-lookup conjuncts are discharged at the acceptance levels", "The adversarial statement: the clauses as the protocol states them"), plus the matching updates in `docs/chip-model-caveats.md` and `docs/operational-soundness.md`.
2. **The endpoints** — `Garden/Orchard/circuit_adversarial.v`: the four residual-hypothesis predicates, the two `…_short_closed` corollaries, the two adversarial corollaries, the two determinism corollaries, and `action_ok_operational`.
3. **The conclusion's shape** — `circuit_proof/adversarial_api.v` (`adversarial_action_conclusion`, `WellTypedInstance`, `typed_inputs_extended`): worth checking that each ⊥ disjunct is a concrete equation and that `WellTypedInstance` contains nothing the circuit could have proved itself.
4. **The ⊥-carrying spec layer** — `circuit_proof/protocol_spec_bot.v`, in particular `hash_to_point_bot_iff` and that `protocol_spec.v`/`internal_spec.v` keep their total functions unchanged.
5. **The three track files** — `note_commit_bot.v`, `ownership_bot.v` (the ladder-nondegeneracy derivation), `merkle_bot.v` (the three-way anchor disjunction), then `adversarial.v` for the assembly.
6. **The closure machinery** — `circuit_proof/lookup_closure.v` (the `ShortSite` derivation and certificates) with its two site-inventory companions.
7. **Building and checking** — a full `make -C Garden` followed by `Print Assumptions` on the corollaries of `circuit_adversarial.v` reproduces the audit; `docs/compile-performance.md` records the certificate costs the new files add.

## Technical details

- **`Garden/Orchard/circuit_proof/`** (8 new files, ~5,600 lines) — `lookup_closure.v`, `lookup_closure_old_note.v`, `lookup_closure_ivk.v` (the short-lookup closure); `protocol_spec_bot.v` (the ⊥-carrying spec variants); `note_commit_bot.v`, `ownership_bot.v`, `merkle_bot.v` (the per-clause disjunctive tracks); `adversarial_api.v` and `adversarial.v` (the statement surface and its assembly from `Holds`).
- **`Garden/Orchard/circuit_adversarial.v`** (new) — the acceptance-level corollaries; heavy certificate files are consumed read-only.
- **Existing files** — `bundle/spec.v` narrows `action_ok` to circuit satisfaction plus the two short-lookup families (both now derived); `cv_net_value.v`, `bundle/main.v` and `bundle/homomorphic_sum.v` shed the corresponding hypotheses; `valid_action_inputs.v` gains comments tying the packages to the adversarial surface. No existing theorem statement is weakened.
- **`docs/`** — `orchard-soundness-proof.md` gains the two claim sections; `chip-model-caveats.md`, `operational-soundness.md`, `orchard-completeness-proof.md`, `orchard-balance-proof.md` and `compile-performance.md` are updated to match.
- **`AGENT.md`** — a "Comment and doc style" section (declarative present tense, resolving references, §x.y.z protocol citations) now applies to all committed comments and docs.
