### PR TITLE
Kernel-check the VK provenance certificates on every PR

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -57,8 +57,9 @@ jobs:
             cd Garden
             # The default build includes the complete generated certificate
             # replay; the generation check and the independent all-44-point
-            # oracle stay as diagnostics.
-            make
+            # oracle stay as diagnostics.  One worker per runner vCPU;
+            # measured per-worker peaks fit inside the runner's memory.
+            make -j"$(nproc)"
             make orchard-vk-provenance-generated-check
             make orchard-vk-provenance-oracle-check
             make snapshot

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -55,10 +55,10 @@ jobs:
           endGroup
           startGroup "Compile the Rocq project"
             cd Garden
+            # The default build includes the complete generated certificate
+            # replay; the generation check and the independent all-44-point
+            # oracle stay as diagnostics.
             make
-            # The complete generated certificate replay is intentionally an
-            # explicit, multi-hour target.  PR CI checks deterministic source
-            # generation and an independent computation of all 44 points.
             make orchard-vk-provenance-generated-check
             make orchard-vk-provenance-oracle-check
             make snapshot

--- a/Garden/Makefile
+++ b/Garden/Makefile
@@ -15,14 +15,11 @@ include vk-provenance.mk
 # depending on whether a developer happens to have generated it already.
 VFILES := $(shell find -L . -path './$(VK_PROVENANCE_GENERATED_DIR)' -prune -o -name "*.v" -print | grep -v -f blacklist.txt | sort)
 
-# The ordinary project build checks every hand-written Rocq source, all
-# generated literal-data modules, and the 278 generated provenance
-# certificate modules.  `make orchard-vk-provenance` remains available as a
-# phased replay with per-group worker caps for memory-constrained builders.
-DEFAULT_VOFILES := \
-	$(VFILES:.v=.vo) \
-	$(VK_PROVENANCE_GENERATED_DATA_VFILES:.v=.vo) \
-	$(VK_PROVENANCE_GENERATED_CERT_VFILES:.v=.vo)
+# The ordinary project build covers every source the generated makefile
+# knows: hand-written Rocq sources, generated literal-data modules, and the
+# 278 generated provenance certificate modules.  `make orchard-vk-provenance`
+# remains available as a phased replay with per-group worker caps for
+# memory-constrained builders.
 
 default: all
 
@@ -40,7 +37,7 @@ MAKECOQ := +$(MAKE) -f CoqMakefile
 	$(MAKECOQ) $@
 
 all: CoqMakefile
-	$(MAKECOQ) $(DEFAULT_VOFILES)
+	$(MAKECOQ) all
 
 ORCHARD_SYNTHESIS_JSON_BUILD := _build/orchard_synthesis_json
 ORCHARD_SNAPSHOTS := Orchard/Snapshots

--- a/Garden/Makefile
+++ b/Garden/Makefile
@@ -15,11 +15,14 @@ include vk-provenance.mk
 # depending on whether a developer happens to have generated it already.
 VFILES := $(shell find -L . -path './$(VK_PROVENANCE_GENERATED_DIR)' -prune -o -name "*.v" -print | grep -v -f blacklist.txt | sort)
 
-# The ordinary project build checks every hand-written Rocq source and all
-# generated literal-data modules.  The dedicated target below owns the 278
-# generated provenance certificate modules; a complete kernel replay of those
-# certificates is `make orchard-vk-provenance`.
-DEFAULT_VOFILES := $(VFILES:.v=.vo) $(VK_PROVENANCE_GENERATED_DATA_VFILES:.v=.vo)
+# The ordinary project build checks every hand-written Rocq source, all
+# generated literal-data modules, and the 278 generated provenance
+# certificate modules.  `make orchard-vk-provenance` remains available as a
+# phased replay with per-group worker caps for memory-constrained builders.
+DEFAULT_VOFILES := \
+	$(VFILES:.v=.vo) \
+	$(VK_PROVENANCE_GENERATED_DATA_VFILES:.v=.vo) \
+	$(VK_PROVENANCE_GENERATED_CERT_VFILES:.v=.vo)
 
 default: all
 

--- a/Garden/Orchard/vk/provenance/ModelColumns.v
+++ b/Garden/Orchard/vk/provenance/ModelColumns.v
@@ -117,8 +117,20 @@ Module VkModelColumns.
       OrchardCompiledCheck.compiled.(CompiledSystem.combination_assignments).
   Proof. reflexivity. Qed.
 
-  Definition all_columns : PrimArray.array Z :=
+  Definition all_columns_computed : PrimArray.array Z :=
     install_combinations combination_columns combination_assignments base_columns.
+
+  (** The virtual machine evaluates a zero-argument constant when it links
+      any code referencing it, including an unselected match branch, so
+      every calibration certificate would otherwise replay the synthesis
+      events and selector compression behind this plane.  Storing the
+      evaluated plane as a literal makes that link cost negligible;
+      [all_columns_spec] pays the full computation once, in this file. *)
+  Definition all_columns : PrimArray.array Z :=
+    Eval vm_compute in all_columns_computed.
+
+  Lemma all_columns_spec : all_columns = all_columns_computed.
+  Proof. vm_cast_no_check (@eq_refl (PrimArray.array Z) all_columns). Qed.
 
   Definition fixed_evaluation (column row : nat) : Z :=
     PrimArray.get all_columns (flat_index column row).

--- a/Garden/Orchard/vk/provenance/ModelColumnsCorrect.v
+++ b/Garden/Orchard/vk/provenance/ModelColumnsCorrect.v
@@ -825,10 +825,17 @@ Module VkModelColumnsCorrect.
           congruence.
   Qed.
 
+  (** Rewriting with [all_columns_spec] first keeps the evaluated-plane
+      literal away from the conversion check: the remaining goal compares
+      [all_columns_computed] with this module's aliases, which unfold to
+      the same application without evaluating anything. *)
   Lemma all_columns_unfold :
     all_columns = install_combinations combination_columns
       combination_assignments base_columns.
-  Proof. reflexivity. Qed.
+  Proof.
+    rewrite VkModelColumns.all_columns_spec.
+    reflexivity.
+  Qed.
 
   (** These structural facts are symbolic consequences of
       [Compress.process], apart from the small closed certificate that its

--- a/Garden/Orchard/vk/provenance/README.md
+++ b/Garden/Orchard/vk/provenance/README.md
@@ -87,16 +87,14 @@ more memory than their source size suggests:
 make -C Garden orchard-vk-provenance
 ```
 
-This explicit target is the full kernel replay of all 278 generated
-certificate modules (229 computational leaves and 49 aggregate or packaging
-modules).  Ordinary `make -C Garden` compiles every
-checked-in refinement theorem and all 129 generated data modules, but omits
-those certificate modules: their conservative serialized runtime is longer
-than a hosted PR runner's build window.  PR CI instead checks deterministic
-source generation and runs the independent all-44-point oracle.  Those fast
-checks are useful diagnostics, but they do not replace the full target above
-when claiming that `OrchardVkProvenance.orchard_vk_commit_lagrange_refined`
-has been kernel-checked.
+`make -C Garden` builds the whole development, including the kernel
+replay of the 278 generated certificate modules (229 computational
+leaves and 49 aggregate or packaging modules); a default build
+kernel-checks `OrchardVkProvenance.orchard_vk_commit_lagrange_refined`.
+The explicit target above performs the same replay in phases with
+per-group worker caps for memory-constrained builders.  PR CI runs the
+default build together with the deterministic-source-generation check
+and the independent all-44-point oracle.
 
 A memory-rich 32-core builder can expose 32-way parallelism for generated
 data and cheap record-packaging leaves with:

--- a/docs/compile-performance.md
+++ b/docs/compile-performance.md
@@ -1291,6 +1291,28 @@ The remaining per-entry floor is the BLAKE2b-XMD hash-to-field stage
 primitive-integer BLAKE2b would be the next lever if the SRS group ever
 needs another order of magnitude.
 
+**Evaluated fixed plane (2026-08-06).** The virtual machine evaluates a
+zero-argument global constant when it links any code that references the
+constant, even from an unselected match branch. Every calibration
+certificate dispatches through `VkCalibration.check`, whose fixed branch
+references `VkModelColumns.fixed_evaluation`, so all 44 leaves —
+permutation ones included — paid the ≈ 74 s evaluation of
+`VkModelColumns.all_columns` (the 19,679-event synthesis replay plus the
+compiled selector-combination planes) just to link. `all_columns` is
+stored as an `Eval vm_compute` literal with the `all_columns_spec` bridge
+back to `all_columns_computed`, paying that evaluation once inside
+`ModelColumns.v` (≈ 6 min for the `Eval` plus the `vm_cast` bridge; the
+`.vo` carries the ≈ 11.6 MB plane). The calibration group drops from
+3 827 s to 656 s CPU (≈ 26 s wall at 32 jobs), and the full certificate
+replay from ≈ 75 to ≈ 22 min CPU. Two cautions: the consumer-side
+`all_columns_unfold` proof must `rewrite all_columns_spec` and close by
+`reflexivity` on the named `all_columns_computed` — an `exact
+all_columns_spec` makes the elaborator convert the literal against the
+`install_combinations` application, which falls into the lazy engine and
+runs for tens of minutes; and any new named checker referenced from a
+generated certificate should keep its zero-argument dependencies literal
+for the same link-time reason.
+
 ## History: the big cost cliffs
 
 **Table alias → pasted literal (2026-07-02).** `full_table_reduced` was

--- a/docs/compile-performance.md
+++ b/docs/compile-performance.md
@@ -54,11 +54,10 @@ dependents.
 dependency proofs. It is a development accelerator only. Any "closed /
 axiom-free" claim, and every `Print Assumptions` audit, must run on a full
 `.vo` build that actually executes the relevant certificate `vm_compute`s.
-`make all` checks the checked-in certificates. The 278 ignored generated
-Orchard VK provenance certificate modules are intentionally outside that target;
-replay them with `make orchard-vk-provenance` before auditing
-`orchard_vk_commit_lagrange_refined`. Treat `-vos` as "compiles and
-type-checks", not "verified".
+`make all` builds every certificate in the development, including the 278
+generated Orchard VK provenance certificate modules; a default build
+suffices for auditing `orchard_vk_commit_lagrange_refined`. Treat `-vos`
+as "compiles and type-checks", not "verified".
 Cautionary tale: `circuit_proof/ladder/main.v`'s `full_window_correct`
 `Qed`s were authored and only ever compiled `-vos`, so they sat unverified
 until their first `-vok` (2026-07-02). Under the forward-progress policy,
@@ -971,10 +970,11 @@ instead.
 That figure was measured over the 399 files of
 `valerii-huhnin@orchard-completeness`, so it predates the compiled-plonkish,
 pinned-vk, transcript-representation, and VK-provenance layers. Ordinary
-`make` includes the checked-in provenance refinements and 129 generated data
-modules. The explicit `make orchard-vk-provenance` replay adds 278 generated
-certificate modules and is outside that historical total. A whole-tree total
-covering both targets has not been measured.
+`make` includes the checked-in provenance refinements, the 129 generated
+data modules, and the 278 generated certificate modules, all outside that
+historical total. A clean default build on a 32-core builder measures
+16 m wall for the sources predating the certificate replay plus roughly
+22 min CPU for the replay itself.
 The 2026-07-06 figure (≈ 1 570 s CPU over 275 files,
 ≈ 212 s ideal wall, wall clock set by the Sinsemilla chain `sinsemilla_s` →
 `chip_proof` → `hash_to_point_round_proof` → `circuit_proof/merkle.v`)
@@ -1213,10 +1213,10 @@ later rewrite pattern; `cbn`'s refolding is load-bearing there.
 
 ### VK-commitment MSM and Vesta SRS provenance
 
-The explicit `make orchard-vk-provenance` target checks 278 generated
-certificate modules: 229 computational leaves and 49 aggregate or packaging
-modules. Ordinary `make` checks the committed refinement code and all 129
-generated literal-data modules, but not those certificates. The detailed
+The default build checks the 278 generated certificate modules: 229
+computational leaves and 49 aggregate or packaging modules. The explicit
+`make orchard-vk-provenance` target performs the same replay in phases
+with per-group worker caps. The detailed
 proof graph and trust boundary are documented in
 [`Orchard/vk/provenance/README.md`](../Garden/Orchard/vk/provenance/README.md).
 


### PR DESCRIPTION
## Summary

This PR makes the Orchard VK provenance replay cheap enough to run in PR CI and then turns it on. After #100 the replay's cost was dominated by the 44 inverse-FFT calibration certificates; deduplicating the shared fixed plane cuts them from 3 827 s to 656 s CPU, bringing the full 278-module replay to about 22 minutes of CPU. The certificate modules join the default build, so `make -C Garden` — locally and on every PR — kernel-checks `OrchardVkProvenance.orchard_vk_commit_lagrange_refined`, and the CI build step runs one worker per runner vCPU, which should leave the whole job faster than a serial build without the replay.

## What changed

**Evaluated fixed plane** (`ModelColumns.v`). The virtual machine evaluates a zero-argument constant when it links any referencing code, even from an unselected match branch. Every calibration certificate dispatches through `VkCalibration.check`, whose fixed branch references the model fixed plane, so all 44 leaves — permutation ones included — paid the ≈ 74 s synthesis replay and selector compression behind `VkModelColumns.all_columns` just to link. The plane is stored as an `Eval vm_compute` literal with the `all_columns_spec` bridge back to the computed form, paying that evaluation once (≈ 6 min in `ModelColumns.v`, ≈ 11.6 MB of `.vo`). Consumers keep the `all_columns_unfold` seam; its proof rewrites through the bridge so the literal never meets the replay expression in a conversion check. `docs/compile-performance.md` records the mechanism and the measurements.

**Certificates build by default** (`Garden/Makefile`, provenance README, `docs/compile-performance.md`). The 278 generated certificate modules join `DEFAULT_VOFILES`, so `make -C Garden` kernel-checks `orchard_vk_commit_lagrange_refined` and PR CI inherits the replay through its ordinary build step, with no dedicated invocation. The phased `orchard-vk-provenance` target with per-group worker caps remains for memory-constrained builders.

**CI parallelism** (`rocq.yml`). The build step runs `make -j"$(nproc)"`; measured per-worker peaks fit four workers inside a hosted runner's memory.

## Verification

The calibration group and its dependent refinement chain re-verify against the literal plane, the default build is green, and the change introduces no `Admitted` or `Axiom`. Local group measurements (32 cores): calibrations 656 s CPU / 26 s wall at 32 jobs; full replay ≈ 22 min CPU / well under 10 min wall. This PR's own CI run is the first hosted-runner measurement of the parallel replay.
